### PR TITLE
docs(github): add and update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -1,0 +1,124 @@
+name: Accessibility issue
+description: Report or propose a fix for an accessibility problem in the design system
+title: '[A11y]: '
+labels: ['accessibility']
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Issue type
+      description: Is this a bug found in production or a proactive improvement proposal?
+      options:
+        - Bug (something is broken or non-compliant)
+        - Improvement (something works but could be more accessible)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the design system is affected?
+      options:
+        - Component (Web Component / SCSS)
+        - Design token (color contrast, spacing)
+        - Storybook / documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: affected
+    attributes:
+      label: Component or token name
+      description: Which specific component or token is affected?
+      placeholder: e.g. Button, Modal, color.text.disabled
+
+  - type: dropdown
+    id: wcag_criterion
+    attributes:
+      label: WCAG criterion
+      description: Which guideline does this relate to? (WCAG 2.1 AA is our baseline)
+      options:
+        - 1.1.1 Non-text Content
+        - 1.3.1 Info and Relationships
+        - 1.3.3 Sensory Characteristics
+        - 1.4.1 Use of Color
+        - 1.4.3 Contrast (Minimum)
+        - 1.4.4 Resize Text
+        - 1.4.11 Non-text Contrast
+        - 2.1.1 Keyboard
+        - 2.1.2 No Keyboard Trap
+        - 2.4.3 Focus Order
+        - 2.4.7 Focus Visible
+        - 3.2.1 On Focus
+        - 3.3.1 Error Identification
+        - 3.3.2 Labels or Instructions
+        - 4.1.1 Parsing
+        - 4.1.2 Name, Role, Value
+        - 4.1.3 Status Messages
+        - Not sure / Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: What is the accessibility problem or gap? Be specific about what is missing or wrong.
+      placeholder: e.g. The Modal component does not trap focus inside when open, allowing keyboard users to tab through elements behind it
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: User impact
+      description: Who is affected and how? Which assistive technologies or interaction modes are impacted?
+      placeholder: |
+        - Affected users: keyboard-only users, screen reader users
+        - Assistive technology: NVDA, VoiceOver
+        - Impact: cannot complete the action without using a mouse
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we verify this issue?
+      placeholder: |
+        1. Open a page with a Modal trigger
+        2. Open the Modal using Enter
+        3. Press Tab repeatedly
+        4. Focus escapes to elements behind the Modal
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed_fix
+    attributes:
+      label: Proposed fix or improvement
+      description: If you have a suggestion for how to address this, describe it here
+      placeholder: e.g. Implement a focus trap using `inert` on background content when the Modal is open
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: WCAG docs, ARIA patterns, audit reports, screenshots, or related issues
+      placeholder: e.g. APG Modal pattern — https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched for existing issues before opening this one
+        - label: I tested with at least one assistive technology (screen reader, keyboard-only)
+        - label: This affects more than one component or token
+        - label: This is a WCAG 2.1 AA violation (not just a best practice)

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report a problem with a component, token, or style
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the design system is affected?
+      options:
+        - Component (Web Component / SCSS)
+        - Design token
+        - CSS output / build
+        - Storybook / documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: affected
+    attributes:
+      label: Component or token name
+      description: If applicable, which specific component or token is affected?
+      placeholder: e.g. Button, color.primary.500
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly and objectively
+      placeholder: e.g. The Button component ignores the `disabled` attribute when used inside a form
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+      placeholder: e.g. The button should be visually disabled and not trigger the click event
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue consistently
+      placeholder: |
+        1. Add `<lets-button disabled>Save</lets-button>` inside a `<form>`
+        2. Click the button
+        3. The form is submitted regardless
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, package version, and any other relevant context
+      placeholder: |
+        - Package version: 1.2.0
+        - Browser: Chrome 124
+        - OS: macOS 14
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Screenshots, recordings, Figma links, or related issues
+      placeholder: e.g. Screenshot or link to a playground reproduction
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched for existing issues before opening this one
+        - label: I can reproduce this consistently
+        - label: This happens in the latest version of the package
+        - label: Accessibility is impacted by this bug

--- a/.github/ISSUE_TEMPLATE/component-request.yml
+++ b/.github/ISSUE_TEMPLATE/component-request.yml
@@ -1,14 +1,43 @@
 name: Component request
-description: Propose the creation of a new component for the design system
+description: Propose the creation or update of a component in the design system
 title: '[Component]: '
 labels: ['component', 'request']
 body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Request type
+      description: Are you requesting a new component or an update to an existing one?
+      options:
+        - New component
+        - Update existing component
+    validations:
+      required: true
+
+  - type: input
+    id: component_name
+    attributes:
+      label: Component name
+      description: For updates, which component? For new components, what would you call it?
+      placeholder: e.g. Button, Badge, Modal
+
   - type: textarea
     id: problem
     attributes:
-      label: What problem does this component solve?
-      description: Describe the context and the pain point that motivated this request
+      label: What problem does this solve?
+      description: Describe the context and pain point that motivated this request
       placeholder: e.g. We have multiple action buttons repeated with inconsistent variations
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_changes
+    attributes:
+      label: Proposed changes
+      description: >
+        **New component:** describe what it should do and how it should look.
+        **Update:** describe what needs to change and why.
+      placeholder: e.g. Add a `loading` state with a spinner inside the button
     validations:
       required: true
 
@@ -29,3 +58,4 @@ body:
         - label: Something similar already exists in the design system
         - label: This could be a variation of an existing component
         - label: This component will be reused across more than one product
+        - label: This change is backwards compatible (for updates only)

--- a/.github/ISSUE_TEMPLATE/design-token.yml
+++ b/.github/ISSUE_TEMPLATE/design-token.yml
@@ -1,4 +1,4 @@
-name: 🎨 Design token request
+name: Design token request
 description: Create or update a design token
 title: '[Token]: '
 labels: ['design-token']

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,38 @@
+name: Question
+description: Ask a question about usage, architecture, or decisions in the design system
+title: '[Question]: '
+labels: ['question']
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Topic
+      description: What is your question about?
+      options:
+        - Component usage
+        - Design tokens
+        - Theming and branding
+        - CSS / SCSS
+        - Web Components
+        - Storybook / documentation
+        - Contributing
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Be as specific as possible — include the context that led to the question
+      placeholder: e.g. What is the recommended way to override a token value for a specific brand without affecting the global theme?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and discussions before asking
+        - label: I checked the documentation and Storybook


### PR DESCRIPTION
## Summary

- Add new issue templates for bug reports, accessibility issues, and general questions
- Update component request template to support both creation and update scenarios

## Type of change

- [x] Documentation update

## What was done

Added three new GitHub issue templates and updated one existing template:

- **Bug report** — structured report with affected area, reproduction steps, environment details, and WCAG impact flag
- **Accessibility** — dedicated template with WCAG 2.1 criterion dropdown, user impact field, and assistive technology checklist
- **Question** — lightweight template for usage and architecture questions, with topic categorization
- **Component request (updated)** — now supports both new component creation and updates to existing ones, with a request type dropdown and proposed changes field

## Related issues

N/A

## Screenshots / Examples

N/A

## Checklist

- [x] My changes follow the project guidelines
- [ ] Tokens were updated only in source files (not generated CSS)
- [ ] Components use semantic HTML and accessible patterns
- [ ] Light and dark modes were considered
- [x] Documentation was updated (if needed)

## Additional notes

N/A