### PR TITLE
feat(alert): add variant icons support

### DIFF
--- a/docs/components/Alert/Alert.stories.js
+++ b/docs/components/Alert/Alert.stories.js
@@ -1,5 +1,6 @@
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
+import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {

--- a/packages/lets-ui-components/src/components/alert.js
+++ b/packages/lets-ui-components/src/components/alert.js
@@ -26,13 +26,14 @@ export class LuiAlert extends HTMLElement {
 
   render() {
     const baseId = ensureElementId(this, 'lui-alert');
-    const variant = this.getAttribute('variant') ?? 'success';
+    const rawVariant = this.getAttribute('variant') ?? 'success';
+    const variant = VARIANT_ICONS[rawVariant] ? rawVariant : 'success';
     const title = this.getAttribute('title') ?? '';
     const content = this.getAttribute('content') ?? '';
     const primaryButton = this.getAttribute('primary-button') ?? '';
     const secondaryButton = this.getAttribute('secondary-button') ?? '';
     const hasActions = primaryButton || secondaryButton;
-    const iconName = VARIANT_ICONS[variant] ?? VARIANT_ICONS.success;
+    const iconName = VARIANT_ICONS[variant];
 
     mountMarkup(
       this,

--- a/packages/lets-ui-components/src/components/alert.js
+++ b/packages/lets-ui-components/src/components/alert.js
@@ -1,5 +1,12 @@
 import { ensureElementId, mountMarkup } from '../internal.js';
 
+const VARIANT_ICONS = {
+  success: 'check-circle',
+  caution: 'alert',
+  danger: 'exclamation-circle',
+  info: 'info-circle',
+};
+
 export class LuiAlert extends HTMLElement {
   static observedAttributes = [
     'variant',
@@ -25,6 +32,7 @@ export class LuiAlert extends HTMLElement {
     const primaryButton = this.getAttribute('primary-button') ?? '';
     const secondaryButton = this.getAttribute('secondary-button') ?? '';
     const hasActions = primaryButton || secondaryButton;
+    const iconName = VARIANT_ICONS[variant] ?? VARIANT_ICONS.success;
 
     mountMarkup(
       this,
@@ -38,6 +46,7 @@ export class LuiAlert extends HTMLElement {
         aria-describedby="${baseId}-content"
       >
         <div class="alert__content">
+          <i class="lui-solid lui-${iconName} alert__icon" aria-hidden="true"></i>
           <div class="alert__text">
             <p id="${baseId}-title" class="body--lg">${title}</p>
             <p id="${baseId}-content" class="body--lg">${content}</p>

--- a/packages/styles/src/components/_alert.scss
+++ b/packages/styles/src/components/_alert.scss
@@ -14,6 +14,12 @@
 
   &__content {
     gap: fluid(16);
+    align-items: flex-start;
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    font-size: fluid(24);
   }
 
   &__text {


### PR DESCRIPTION
## Summary

- Adds automatic icons to `Alert` component based on variant (`success`, `caution`, `danger`, `info`)
- Maps each variant to a corresponding `lets-ui-icons` icon via a `VARIANT_ICONS` lookup table
- Updates alert SCSS to align icon properly (`flex-start`, `flex-shrink: 0`, fluid font-size)
- Imports `lets-ui-icons` CSS in Storybook stories for icon rendering

## Test plan

- [x] Render each Alert variant (`success`, `caution`, `danger`, `info`) and confirm the correct icon appears
- [x] Confirm icon is hidden from screen readers (`aria-hidden="true"`)
- [x] Confirm layout doesn't break with long content (icon stays top-aligned with `align-items: flex-start`)
- [x] Check that alerts without a recognised variant fall back to the `success` icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)