### PR TITLE
feat(drawer,modal): xl size, shadow fix, and modal close button

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,4 +1,6 @@
 node_modules
+**/node_modules
 dist
 build
+storybook-static
 .agent

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,4 +1,5 @@
 node_modules
 dist
 build
+storybook-static
 **/*.min.css

--- a/docs/components/Alert/Alert.stories.js
+++ b/docs/components/Alert/Alert.stories.js
@@ -12,37 +12,24 @@ export default {
     },
     title: { control: 'text' },
     content: { control: 'text' },
-    primaryButton: { control: 'text' },
-    secondaryButton: { control: 'text' },
   },
 };
 
-const Template = ({
-  variant,
-  title,
-  content,
-  primaryButton,
-  secondaryButton,
-}) => {
-  const attrs = [
-    `variant="${variant ?? 'success'}"`,
-    `title="${title ?? ''}"`,
-    `content="${content ?? ''}"`,
-    primaryButton ? `primary-button="${primaryButton}"` : '',
-    secondaryButton ? `secondary-button="${secondaryButton}"` : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
-
-  return `<lui-alert ${attrs}></lui-alert>`;
-};
+const Template = ({ variant, title, content }) => `
+  <lui-alert
+    variant="${variant ?? 'success'}"
+    title="${title ?? ''}"
+    content="${content ?? ''}"
+  >
+    <button slot="actions" class="btn btn--secondary btn--lg">Dismiss</button>
+    <button slot="actions" class="btn btn--primary btn--lg">Action</button>
+  </lui-alert>
+`;
 
 const baseArgs = {
   variant: 'success',
   title: 'Alert title',
   content: 'Description',
-  primaryButton: 'Button',
-  secondaryButton: 'Button',
 };
 
 export const Alert = Template.bind({});
@@ -59,3 +46,12 @@ Danger.args = { ...baseArgs, variant: 'danger' };
 
 export const Info = Template.bind({});
 Info.args = { ...baseArgs, variant: 'info' };
+
+export const WithoutActions = () => `
+  <lui-alert
+    variant="success"
+    title="Alert sem ações"
+    content="Este alert não possui botões de ação."
+  ></lui-alert>
+`;
+WithoutActions.storyName = 'Without actions';

--- a/docs/components/Drawer/Drawer.stories.js
+++ b/docs/components/Drawer/Drawer.stories.js
@@ -12,26 +12,15 @@ export default {
       options: ['sm', 'md', 'lg'],
     },
     triggerLabel: { control: 'text' },
-    primaryButton: { control: 'text' },
-    secondaryButton: { control: 'text' },
     closeOnBackdrop: { control: 'boolean' },
   },
 };
 
-const Template = ({
-  title,
-  size,
-  triggerLabel,
-  primaryButton,
-  secondaryButton,
-  closeOnBackdrop,
-}) => {
+const Template = ({ title, size, triggerLabel, closeOnBackdrop }) => {
   const attrs = [
     `title="${title ?? 'Drawer title'}"`,
     `size="${size ?? 'md'}"`,
     `trigger-label="${triggerLabel ?? 'Abrir drawer'}"`,
-    primaryButton ? `primary-button="${primaryButton}"` : '',
-    secondaryButton ? `secondary-button="${secondaryButton}"` : '',
     closeOnBackdrop ? 'close-on-backdrop' : '',
   ]
     .filter(Boolean)
@@ -41,6 +30,8 @@ const Template = ({
     <lui-drawer ${attrs}>
       <p>Conteúdo do drawer. Pode ser qualquer elemento HTML ou componente.</p>
       <p style="margin-top: 12px;">Use o drawer para exibir detalhes, configurações ou ações secundárias sem sair do contexto da página principal.</p>
+      <button slot="actions" data-drawer-close class="btn btn--secondary btn--lg">Cancelar</button>
+      <button slot="actions" class="btn btn--primary btn--lg">Confirmar</button>
     </lui-drawer>
   `;
 };
@@ -50,8 +41,6 @@ Drawer.args = {
   title: 'Título do drawer',
   size: 'md',
   triggerLabel: 'Abrir drawer',
-  primaryButton: 'Confirmar',
-  secondaryButton: 'Cancelar',
   closeOnBackdrop: true,
 };
 
@@ -69,13 +58,11 @@ Large.args = {
   size: 'lg',
 };
 
-export const WithoutActions = Template.bind({});
-WithoutActions.args = {
-  ...Drawer.args,
-  title: 'Drawer sem ações',
-  primaryButton: '',
-  secondaryButton: '',
-};
+export const WithoutActions = () => `
+  <lui-drawer title="Drawer sem ações" trigger-label="Abrir drawer" close-on-backdrop>
+    <p>Este drawer não possui botões de ação no rodapé.</p>
+  </lui-drawer>
+`;
 WithoutActions.storyName = 'Sem ações';
 
 export const CloseOnBackdropOff = Template.bind({});
@@ -87,13 +74,15 @@ CloseOnBackdropOff.args = {
 CloseOnBackdropOff.storyName = 'close-on-backdrop: false';
 
 export const CustomTrigger = () => `
-  <lui-drawer title="Drawer com trigger customizado" primary-button="Confirmar" secondary-button="Cancelar" close-on-backdrop>
+  <lui-drawer title="Drawer com trigger customizado" close-on-backdrop>
     <button slot="trigger" class="btn btn--secondary btn--lg">
       <i class="lui lui-settings" aria-hidden="true"></i>
       Configurações
     </button>
     <p>Conteúdo do drawer com trigger totalmente customizado via <code>slot="trigger"</code>.</p>
     <p style="margin-top: 12px;">Qualquer elemento ou componente pode ser o trigger — basta adicionar o atributo <code>slot="trigger"</code>.</p>
+    <button slot="actions" data-drawer-close class="btn btn--secondary btn--lg">Cancelar</button>
+    <button slot="actions" class="btn btn--primary btn--lg">Confirmar</button>
   </lui-drawer>
 `;
 CustomTrigger.storyName = 'Trigger customizado (slot)';

--- a/docs/components/Drawer/Drawer.stories.js
+++ b/docs/components/Drawer/Drawer.stories.js
@@ -9,7 +9,7 @@ export default {
     title: { control: 'text' },
     size: {
       control: { type: 'select' },
-      options: ['sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'xl'],
     },
     triggerLabel: { control: 'text' },
     closeOnBackdrop: { control: 'boolean' },
@@ -72,6 +72,14 @@ CloseOnBackdropOff.args = {
   closeOnBackdrop: false,
 };
 CloseOnBackdropOff.storyName = 'close-on-backdrop: false';
+
+export const XLarge = Template.bind({});
+XLarge.args = {
+  ...Drawer.args,
+  title: 'Drawer extra grande',
+  size: 'xl',
+};
+XLarge.storyName = 'Extra Large (xl)';
 
 export const CustomTrigger = () => `
   <lui-drawer title="Drawer com trigger customizado" close-on-backdrop>

--- a/docs/components/Drawer/Drawer.stories.js
+++ b/docs/components/Drawer/Drawer.stories.js
@@ -85,3 +85,15 @@ CloseOnBackdropOff.args = {
   closeOnBackdrop: false,
 };
 CloseOnBackdropOff.storyName = 'close-on-backdrop: false';
+
+export const CustomTrigger = () => `
+  <lui-drawer title="Drawer com trigger customizado" primary-button="Confirmar" secondary-button="Cancelar" close-on-backdrop>
+    <button slot="trigger" class="btn btn--secondary btn--lg">
+      <i class="lui lui-settings" aria-hidden="true"></i>
+      Configurações
+    </button>
+    <p>Conteúdo do drawer com trigger totalmente customizado via <code>slot="trigger"</code>.</p>
+    <p style="margin-top: 12px;">Qualquer elemento ou componente pode ser o trigger — basta adicionar o atributo <code>slot="trigger"</code>.</p>
+  </lui-drawer>
+`;
+CustomTrigger.storyName = 'Trigger customizado (slot)';

--- a/docs/components/Modal/Modal.stories.js
+++ b/docs/components/Modal/Modal.stories.js
@@ -1,19 +1,17 @@
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
+import 'lets-ui-icons/dist/lets-ui-icons.css';
+import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
   title: 'Components/Modal',
   argTypes: {
-    title: {
-      control: 'text',
-    },
-    body: {
-      control: 'text',
-    },
+    title: { control: 'text' },
     size: {
       control: { type: 'select' },
-      options: ['lg', 'md', 'sm'],
+      options: ['sm', 'md', 'lg'],
     },
+    triggerLabel: { control: 'text' },
   },
   parameters: {
     docs: {
@@ -25,51 +23,59 @@ export default {
   },
 };
 
-const Template = ({ title, body, size }) => {
-  const dialogClasses = ['modal', size && `modal--${size}`]
-    .filter(Boolean)
-    .join(' ');
+const Template = ({ title, size, triggerLabel }) => {
+  const attrs = [
+    `title="${title ?? 'Modal title'}"`,
+    `size="${size ?? 'md'}"`,
+    `trigger-label="${triggerLabel ?? 'Open modal'}"`,
+  ].join(' ');
 
   return `
-      <div class="${dialogClasses}" tabindex="-1" role="dialog">
-        <div class="modal__header">
-          ${title}
-        </div>
-        <div class="modal__body">
-          <p>${body}</p>
-        </div>
-        <div class="modal__footer">
-          <button class="btn btn--secondary btn--lg">Cancel</button>
-          <button class="btn btn--primary btn--lg">Confirm</button>
-        </div>
-      </div>
+    <lui-modal ${attrs}>
+      <p>This is the modal body text. It defines the main content of the modal.</p>
+      <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancel</button>
+      <button slot="actions" class="btn btn--primary btn--lg">Confirm</button>
+    </lui-modal>
   `;
 };
 
 export const Default = Template.bind({});
 Default.args = {
   title: 'Modal title',
-  body: 'This is the modal body text. It defines the main content of the modal.',
   size: 'md',
-};
-
-export const Large = Template.bind({});
-Large.args = {
-  ...Default.args,
-  size: 'lg',
-  title: 'Large Modal',
-};
-
-export const Medium = Template.bind({});
-Medium.args = {
-  ...Default.args,
-  size: 'md',
-  title: 'Medium Modal',
+  triggerLabel: 'Open modal',
 };
 
 export const Small = Template.bind({});
 Small.args = {
   ...Default.args,
-  size: 'sm',
   title: 'Small Modal',
+  size: 'sm',
 };
+
+export const Large = Template.bind({});
+Large.args = {
+  ...Default.args,
+  title: 'Large Modal',
+  size: 'lg',
+};
+
+export const WithoutActions = () => `
+  <lui-modal title="Modal without actions" trigger-label="Open modal">
+    <p>This modal has no footer actions.</p>
+  </lui-modal>
+`;
+WithoutActions.storyName = 'Without actions';
+
+export const CustomTrigger = () => `
+  <lui-modal title="Modal with custom trigger">
+    <button slot="trigger" class="btn btn--secondary btn--lg">
+      <i class="lui lui-settings" aria-hidden="true"></i>
+      Settings
+    </button>
+    <p>This modal uses a fully custom trigger via <code>slot="trigger"</code>.</p>
+    <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancel</button>
+    <button slot="actions" class="btn btn--primary btn--lg">Confirm</button>
+  </lui-modal>
+`;
+CustomTrigger.storyName = 'Custom trigger (slot)';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "pnpm -r build",
     "lint": "pnpm run lint:css && pnpm run lint:md",
     "lint:css": "stylelint \"**/*.{css,scss}\"",
-    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"!node_modules/**\" \"!storybook-static/**\"",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "deploy-storybook": "pnpm run build-storybook && gh-pages -b storybook -d storybook-static",

--- a/packages/lets-ui-components/src/components/alert.js
+++ b/packages/lets-ui-components/src/components/alert.js
@@ -8,20 +8,52 @@ const VARIANT_ICONS = {
 };
 
 export class LuiAlert extends HTMLElement {
-  static observedAttributes = [
-    'variant',
-    'title',
-    'content',
-    'primary-button',
-    'secondary-button',
-  ];
+  static observedAttributes = ['variant', 'title', 'content'];
 
   connectedCallback() {
-    this.render();
+    if (this._initialized) {
+      return;
+    }
+
+    this._initialized = true;
+
+    queueMicrotask(() => {
+      this.captureInitialContent();
+      this.render();
+    });
   }
 
   attributeChangedCallback() {
+    if (!this._initialized) {
+      return;
+    }
+
     this.render();
+  }
+
+  captureInitialContent() {
+    if (this._contentCaptured) {
+      return;
+    }
+
+    const actions = [];
+
+    Array.from(this.childNodes).forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '') {
+        return;
+      }
+
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        return;
+      }
+
+      if (node.getAttribute('slot') === 'actions') {
+        actions.push(node.outerHTML);
+      }
+    });
+
+    this._actionsHtml = actions.join('');
+    this._contentCaptured = true;
   }
 
   render() {
@@ -30,10 +62,8 @@ export class LuiAlert extends HTMLElement {
     const variant = VARIANT_ICONS[rawVariant] ? rawVariant : 'success';
     const title = this.getAttribute('title') ?? '';
     const content = this.getAttribute('content') ?? '';
-    const primaryButton = this.getAttribute('primary-button') ?? '';
-    const secondaryButton = this.getAttribute('secondary-button') ?? '';
-    const hasActions = primaryButton || secondaryButton;
     const iconName = VARIANT_ICONS[variant];
+    const hasActions = Boolean(this._actionsHtml?.trim());
 
     mountMarkup(
       this,
@@ -53,16 +83,7 @@ export class LuiAlert extends HTMLElement {
             <p id="${baseId}-content" class="body--lg">${content}</p>
           </div>
         </div>
-        ${
-          hasActions
-            ? `
-          <div class="alert__actions">
-            ${secondaryButton ? `<button class="btn btn--secondary btn--lg">${secondaryButton}</button>` : ''}
-            ${primaryButton ? `<button class="btn btn--primary btn--lg">${primaryButton}</button>` : ''}
-          </div>
-        `
-            : ''
-        }
+        ${hasActions ? `<div class="alert__actions">${this._actionsHtml}</div>` : ''}
       </div>
       `
     );

--- a/packages/lets-ui-components/src/components/drawer.js
+++ b/packages/lets-ui-components/src/components/drawer.js
@@ -23,8 +23,6 @@ export class LuiDrawer extends HTMLElement {
     'open',
     'trigger-label',
     'hide-trigger',
-    'primary-button',
-    'secondary-button',
     'close-on-backdrop',
   ];
 
@@ -95,6 +93,7 @@ export class LuiDrawer extends HTMLElement {
     }
 
     const triggerNodes = [];
+    const actionNodes = [];
     const bodyNodes = [];
 
     Array.from(this.childNodes).forEach((node) => {
@@ -102,21 +101,23 @@ export class LuiDrawer extends HTMLElement {
         return;
       }
 
-      if (
-        node.nodeType === Node.ELEMENT_NODE &&
-        node.getAttribute('slot') === 'trigger'
-      ) {
-        triggerNodes.push(node.outerHTML);
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const slot = node.getAttribute('slot');
+
+        if (slot === 'trigger') {
+          triggerNodes.push(node.outerHTML);
+        } else if (slot === 'actions') {
+          actionNodes.push(node.outerHTML);
+        } else {
+          bodyNodes.push(node.outerHTML);
+        }
       } else {
-        bodyNodes.push(
-          node.nodeType === Node.ELEMENT_NODE
-            ? node.outerHTML
-            : node.textContent
-        );
+        bodyNodes.push(node.textContent);
       }
     });
 
     this._triggerHtml = triggerNodes.join('');
+    this._actionsHtml = actionNodes.join('');
     this._bodyHtml = bodyNodes.join('');
     this._contentCaptured = true;
   }
@@ -264,9 +265,7 @@ export class LuiDrawer extends HTMLElement {
     const open = hasBooleanAttribute(this, 'open');
     const hideTrigger = hasBooleanAttribute(this, 'hide-trigger');
     const triggerLabel = this.getAttribute('trigger-label') ?? 'Abrir drawer';
-    const primaryButton = this.getAttribute('primary-button') ?? '';
-    const secondaryButton = this.getAttribute('secondary-button') ?? '';
-    const hasActions = primaryButton || secondaryButton;
+    const hasActions = Boolean(this._actionsHtml?.trim());
     const hasSlottedTrigger = Boolean(this._triggerHtml?.trim());
 
     mountMarkup(
@@ -320,16 +319,7 @@ export class LuiDrawer extends HTMLElement {
           ${this._bodyHtml ?? ''}
         </div>
 
-        ${
-          hasActions
-            ? `
-          <div class="drawer__footer">
-            ${secondaryButton ? `<button type="button" data-drawer-close class="btn btn--secondary btn--lg">${secondaryButton}</button>` : ''}
-            ${primaryButton ? `<button type="button" class="btn btn--primary btn--lg">${primaryButton}</button>` : ''}
-          </div>
-        `
-            : ''
-        }
+        ${hasActions ? `<div class="drawer__footer">${this._actionsHtml}</div>` : ''}
       </div>
       `
     );

--- a/packages/lets-ui-components/src/components/drawer.js
+++ b/packages/lets-ui-components/src/components/drawer.js
@@ -307,7 +307,7 @@ export class LuiDrawer extends HTMLElement {
           <span id="${baseId}-title" class="drawer__title">${title}</span>
           <button
             type="button"
-            class="icon-button icon-button--md"
+            class="icon-button icon-button--lg"
             data-drawer-close
             aria-label="Fechar drawer"
           >

--- a/packages/lets-ui-components/src/components/drawer.js
+++ b/packages/lets-ui-components/src/components/drawer.js
@@ -94,19 +94,30 @@ export class LuiDrawer extends HTMLElement {
       return;
     }
 
-    const nodes = [];
+    const triggerNodes = [];
+    const bodyNodes = [];
 
     Array.from(this.childNodes).forEach((node) => {
       if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '') {
         return;
       }
 
-      nodes.push(
-        node.nodeType === Node.ELEMENT_NODE ? node.outerHTML : node.textContent
-      );
+      if (
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.getAttribute('slot') === 'trigger'
+      ) {
+        triggerNodes.push(node.outerHTML);
+      } else {
+        bodyNodes.push(
+          node.nodeType === Node.ELEMENT_NODE
+            ? node.outerHTML
+            : node.textContent
+        );
+      }
     });
 
-    this._bodyHtml = nodes.join('');
+    this._triggerHtml = triggerNodes.join('');
+    this._bodyHtml = bodyNodes.join('');
     this._contentCaptured = true;
   }
 
@@ -130,7 +141,9 @@ export class LuiDrawer extends HTMLElement {
     const isOpen = hasBooleanAttribute(this, 'open');
     const backdrop = this.querySelector('[data-drawer-backdrop]');
     const panel = this.querySelector('[data-drawer-panel]');
-    const trigger = this.querySelector('[data-drawer-trigger]');
+    const trigger =
+      this.querySelector('[data-drawer-trigger]') ??
+      this.querySelector('[slot="trigger"]');
 
     if (!panel || !backdrop) {
       return;
@@ -212,13 +225,23 @@ export class LuiDrawer extends HTMLElement {
   }
 
   attachEvents() {
-    const trigger = this.querySelector('[data-drawer-trigger]');
+    const trigger =
+      this.querySelector('[data-drawer-trigger]') ??
+      this.querySelector('[slot="trigger"]');
     const backdrop = this.querySelector('[data-drawer-backdrop]');
     const closeButtons = this.querySelectorAll('[data-drawer-close]');
     const closeOnBackdrop = hasBooleanAttribute(this, 'close-on-backdrop');
 
     if (trigger) {
       trigger.onclick = () => this.open();
+
+      if (!trigger.hasAttribute('data-drawer-trigger')) {
+        const panel = this.querySelector('[data-drawer-panel]');
+        trigger.setAttribute('aria-haspopup', 'dialog');
+        if (panel) {
+          trigger.setAttribute('aria-controls', panel.id);
+        }
+      }
     }
 
     closeButtons.forEach((btn) => {
@@ -244,14 +267,17 @@ export class LuiDrawer extends HTMLElement {
     const primaryButton = this.getAttribute('primary-button') ?? '';
     const secondaryButton = this.getAttribute('secondary-button') ?? '';
     const hasActions = primaryButton || secondaryButton;
+    const hasSlottedTrigger = Boolean(this._triggerHtml?.trim());
 
     mountMarkup(
       this,
       `
       ${
-        hideTrigger
-          ? ''
-          : `<button
+        hasSlottedTrigger
+          ? this._triggerHtml
+          : hideTrigger
+            ? ''
+            : `<button
           type="button"
           data-drawer-trigger
           class="btn btn--primary btn--lg"

--- a/packages/lets-ui-components/src/components/modal.js
+++ b/packages/lets-ui-components/src/components/modal.js
@@ -67,6 +67,7 @@ export class LuiModal extends HTMLElement {
       return;
     }
 
+    const triggers = [];
     const actions = [];
 
     Array.from(this.childNodes).forEach((node) => {
@@ -74,14 +75,20 @@ export class LuiModal extends HTMLElement {
         return;
       }
 
-      if (
-        node.nodeType === Node.ELEMENT_NODE &&
-        node.getAttribute('slot') === 'actions'
-      ) {
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        return;
+      }
+
+      const slot = node.getAttribute('slot');
+
+      if (slot === 'trigger') {
+        triggers.push(node.outerHTML);
+      } else if (slot === 'actions') {
         actions.push(node.outerHTML);
       }
     });
 
+    this._triggerHtml = triggers.join('');
     this._actionsHtml = actions.join('');
     this._actionsCaptured = true;
   }
@@ -138,7 +145,9 @@ export class LuiModal extends HTMLElement {
   }
 
   attachEvents() {
-    const trigger = this.querySelector('[data-modal-trigger]');
+    const trigger =
+      this.querySelector('[data-modal-trigger]') ??
+      this.querySelector('[slot="trigger"]');
     const backdrop = this.querySelector('[data-modal-backdrop]');
     const dialog = this.querySelector('[data-modal-dialog]');
     const closeButtons = this.querySelectorAll('[data-modal-close]');
@@ -146,6 +155,14 @@ export class LuiModal extends HTMLElement {
 
     if (trigger) {
       trigger.onclick = () => this.open();
+
+      if (!trigger.hasAttribute('data-modal-trigger')) {
+        trigger.setAttribute('aria-haspopup', 'dialog');
+        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        if (dialog) {
+          trigger.setAttribute('aria-controls', dialog.id);
+        }
+      }
     }
 
     closeButtons.forEach((button) => {
@@ -175,6 +192,7 @@ export class LuiModal extends HTMLElement {
     const open = hasBooleanAttribute(this, 'open');
     const hideTrigger = hasBooleanAttribute(this, 'hide-trigger');
     const triggerLabel = this.getAttribute('trigger-label') ?? 'Open modal';
+    const hasSlottedTrigger = Boolean(this._triggerHtml?.trim());
     const hasSlottedActions = Boolean(
       this._actionsHtml && this._actionsHtml.trim()
     );
@@ -183,9 +201,11 @@ export class LuiModal extends HTMLElement {
       this,
       `
       ${
-        hideTrigger
-          ? ''
-          : `<button
+        hasSlottedTrigger
+          ? this._triggerHtml
+          : hideTrigger
+            ? ''
+            : `<button
           type="button"
           data-modal-trigger
           class="btn btn--primary btn--lg"

--- a/packages/lets-ui-components/src/components/modal.js
+++ b/packages/lets-ui-components/src/components/modal.js
@@ -237,7 +237,17 @@ export class LuiModal extends HTMLElement {
           aria-labelledby="${baseId}-title"
           aria-describedby="${baseId}-body"
         >
-          <div id="${baseId}-title" class="modal__header">${title}</div>
+          <div class="modal__header">
+            <span id="${baseId}-title" class="modal__title">${title}</span>
+            <button
+              type="button"
+              class="icon-button icon-button--lg"
+              data-modal-close
+              aria-label="Fechar modal"
+            >
+              <i class="lui lui-x" aria-hidden="true"></i>
+            </button>
+          </div>
           <div id="${baseId}-body" class="modal__body">
             ${this._bodyHtml ?? ''}
           </div>

--- a/packages/lets-ui-components/src/components/modal.js
+++ b/packages/lets-ui-components/src/components/modal.js
@@ -10,7 +10,6 @@ import {
 export class LuiModal extends HTMLElement {
   static observedAttributes = [
     'title',
-    'body',
     'size',
     'open',
     'trigger-label',
@@ -40,7 +39,7 @@ export class LuiModal extends HTMLElement {
 
     document.addEventListener('keydown', this.handleDocumentKeydown);
     queueMicrotask(() => {
-      this.captureInitialActions();
+      this.captureInitialContent();
       this.render();
       this.attachEvents();
     });
@@ -62,13 +61,14 @@ export class LuiModal extends HTMLElement {
     }
   }
 
-  captureInitialActions() {
-    if (this._actionsCaptured) {
+  captureInitialContent() {
+    if (this._contentCaptured) {
       return;
     }
 
     const triggers = [];
     const actions = [];
+    const bodyNodes = [];
 
     Array.from(this.childNodes).forEach((node) => {
       if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '') {
@@ -85,12 +85,15 @@ export class LuiModal extends HTMLElement {
         triggers.push(node.outerHTML);
       } else if (slot === 'actions') {
         actions.push(node.outerHTML);
+      } else {
+        bodyNodes.push(node.outerHTML);
       }
     });
 
     this._triggerHtml = triggers.join('');
     this._actionsHtml = actions.join('');
-    this._actionsCaptured = true;
+    this._bodyHtml = bodyNodes.join('');
+    this._contentCaptured = true;
   }
 
   open() {
@@ -185,17 +188,12 @@ export class LuiModal extends HTMLElement {
   render() {
     const baseId = ensureElementId(this, 'lui-modal');
     const title = this.getAttribute('title') ?? 'Modal title';
-    const body =
-      this.getAttribute('body') ??
-      'This is the modal body text. It defines the main content of the modal.';
     const size = readSize(this, 'md');
     const open = hasBooleanAttribute(this, 'open');
     const hideTrigger = hasBooleanAttribute(this, 'hide-trigger');
     const triggerLabel = this.getAttribute('trigger-label') ?? 'Open modal';
     const hasSlottedTrigger = Boolean(this._triggerHtml?.trim());
-    const hasSlottedActions = Boolean(
-      this._actionsHtml && this._actionsHtml.trim()
-    );
+    const hasActions = Boolean(this._actionsHtml?.trim());
 
     mountMarkup(
       this,
@@ -241,18 +239,9 @@ export class LuiModal extends HTMLElement {
         >
           <div id="${baseId}-title" class="modal__header">${title}</div>
           <div id="${baseId}-body" class="modal__body">
-            <p>${body}</p>
+            ${this._bodyHtml ?? ''}
           </div>
-          <div class="modal__footer">
-            ${
-              hasSlottedActions
-                ? this._actionsHtml
-                : `
-              <button type="button" data-modal-close class="btn btn--secondary btn--lg">Cancel</button>
-              <button type="button" data-modal-close class="btn btn--primary btn--lg">Confirm</button>
-            `
-            }
-          </div>
+          ${hasActions ? `<div class="modal__footer">${this._actionsHtml}</div>` : ''}
         </div>
       </div>
       `

--- a/packages/lets-ui-components/src/internal.js
+++ b/packages/lets-ui-components/src/internal.js
@@ -25,7 +25,9 @@ export function mountMarkup(host, markup) {
 
 export function readSize(element, fallback = 'md') {
   const size = element.getAttribute('size') ?? fallback;
-  return size === 'lg' || size === 'md' || size === 'sm' ? size : fallback;
+  return size === 'xl' || size === 'lg' || size === 'md' || size === 'sm'
+    ? size
+    : fallback;
 }
 
 export function ensureElementId(element, prefix) {

--- a/packages/styles/src/components/_alert.scss
+++ b/packages/styles/src/components/_alert.scss
@@ -39,10 +39,7 @@
   &__actions {
     margin-top: fluid(24);
     justify-content: flex-end;
-
-    button:last-child {
-      margin-left: fluid(16);
-    }
+    gap: fluid(16);
   }
 
   $border-color: caution, danger, info, success;

--- a/packages/styles/src/components/_button.scss
+++ b/packages/styles/src/components/_button.scss
@@ -45,6 +45,10 @@ $size: (
   ),
 );
 
+lui-button {
+  display: contents;
+}
+
 button {
   &.btn {
     position: relative;

--- a/packages/styles/src/components/_drawer.scss
+++ b/packages/styles/src/components/_drawer.scss
@@ -1,6 +1,12 @@
 @use 'utilities/src/functions' as *;
 @use 'utilities/src/mixins' as *;
 
+$size: (
+  'sm': 320px,
+  'md': 480px,
+  'lg': 640px,
+);
+
 lui-drawer {
   display: contents;
 }
@@ -34,25 +40,31 @@ lui-drawer {
   width: 100%;
   background-color: bg(surface, neutral);
   border-radius: radius(xl) radius(none) radius(none) radius(xl);
-  box-shadow: elevation(overlay);
+  box-shadow: none;
   outline: 0;
   transform: translateX(100%);
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s ease;
 
   &.is-open {
+    box-shadow: elevation(overlay);
     transform: translateX(0);
   }
 
-  &--sm {
-    max-width: 320px;
+  &--xl {
+    max-width: 100vw;
+    border-radius: radius(none);
   }
 
-  &--md {
-    max-width: 480px;
-  }
+  @each $size, $value in $size {
+    &--#{$size} {
+      max-width: $value;
 
-  &--lg {
-    max-width: 640px;
+      @media (max-width: $value) {
+        border-radius: radius(none);
+      }
+    }
   }
 
   &__header {
@@ -60,7 +72,7 @@ lui-drawer {
     @include font-scale(block-title);
 
     flex-shrink: 0;
-    padding: fluid(24);
+    padding: fluid(24) fluid(24) fluid(8);
     color: text(heading);
   }
 

--- a/packages/styles/src/components/_modal.scss
+++ b/packages/styles/src/components/_modal.scss
@@ -31,14 +31,16 @@
   }
 
   &__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: fluid(24);
-
+    @include flex(row, center, space-between, fluid(16), nowrap);
     @include font-scale(block-title);
 
+    flex-shrink: 0;
+    padding: fluid(24) fluid(24) fluid(8);
     color: text(heading);
+  }
+
+  &__title {
+    flex: 1;
   }
 
   &__body {

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Playground — Let's UI</title>
+    <link rel="stylesheet" href="../packages/lets-ui-tokens/dist/letsui.tokens.css" />
+    <link rel="stylesheet" href="../packages/styles/dist/letsui.css" />
+    <link rel="stylesheet" href="../node_modules/lets-ui-icons/dist/lets-ui-icons.css" />
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 48px 32px;
+        background: var(--color-bg-surface-neutral, #f5f5f5);
+        display: flex;
+        flex-direction: column;
+        gap: 48px;
+      }
+
+      section {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      h2 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        opacity: 0.5;
+      }
+
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Modal: trigger padrão -->
+    <section>
+      <h2>Modal — trigger padrão</h2>
+      <div class="row">
+        <lui-modal
+          title="Modal padrão"
+          body="Este modal usa o trigger interno gerado pelo componente."
+          trigger-label="Abrir modal"
+        ></lui-modal>
+      </div>
+    </section>
+
+    <!-- Modal: slot="trigger" customizado -->
+    <section>
+      <h2>Modal — slot="trigger" customizado</h2>
+      <div class="row">
+        <lui-modal title="Modal com trigger customizado" body="O trigger é qualquer elemento definido com slot=&quot;trigger&quot;.">
+          <button slot="trigger" class="btn btn--secondary btn--lg">
+            <i class="lui lui-settings" aria-hidden="true"></i>
+            Configurações
+          </button>
+          <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancelar</button>
+          <button slot="actions" data-modal-close class="btn btn--primary btn--lg">Salvar</button>
+        </lui-modal>
+
+        <lui-modal title="Confirmar exclusão" body="Esta ação não pode ser desfeita.">
+          <button slot="trigger" class="btn btn--danger btn--lg">
+            <i class="lui lui-trash" aria-hidden="true"></i>
+            Excluir item
+          </button>
+          <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancelar</button>
+          <button slot="actions" data-modal-close class="btn btn--danger btn--lg">Excluir</button>
+        </lui-modal>
+
+        <lui-modal title="Informações" body="Acesse os detalhes do item selecionado.">
+          <button slot="trigger" class="icon-button icon-button--md" aria-label="Ver informações">
+            <i class="lui lui-info-circle" aria-hidden="true"></i>
+          </button>
+        </lui-modal>
+      </div>
+    </section>
+
+    <!-- Drawer: trigger padrão -->
+    <section>
+      <h2>Drawer — trigger padrão</h2>
+      <div class="row">
+        <lui-drawer
+          title="Drawer padrão"
+          trigger-label="Abrir drawer"
+          primary-button="Confirmar"
+          secondary-button="Cancelar"
+          close-on-backdrop
+        >
+          <p>Conteúdo do drawer com trigger interno gerado pelo componente.</p>
+        </lui-drawer>
+      </div>
+    </section>
+
+    <!-- Drawer: slot="trigger" customizado -->
+    <section>
+      <h2>Drawer — slot="trigger" customizado</h2>
+      <div class="row">
+        <lui-drawer title="Filtros" primary-button="Aplicar" secondary-button="Limpar" close-on-backdrop>
+          <button slot="trigger" class="btn btn--secondary btn--lg">
+            <i class="lui lui-filter" aria-hidden="true"></i>
+            Filtros
+          </button>
+          <p>Defina os filtros para refinar os resultados.</p>
+        </lui-drawer>
+
+        <lui-drawer title="Notificações" close-on-backdrop>
+          <button slot="trigger" class="icon-button icon-button--md" aria-label="Abrir notificações">
+            <i class="lui lui-bell" aria-hidden="true"></i>
+          </button>
+          <p>Você não tem notificações no momento.</p>
+        </lui-drawer>
+
+        <lui-drawer title="Editar perfil" primary-button="Salvar" secondary-button="Cancelar" close-on-backdrop>
+          <lui-icon-button slot="trigger" label="Editar perfil" icon="pencil"></lui-icon-button>
+          <p>Edite as informações do seu perfil.</p>
+        </lui-drawer>
+      </div>
+    </section>
+
+    <script type="module" src="../packages/lets-ui-components/src/index.js"></script>
+  </body>
+</html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,12 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Playground — Let's UI</title>
-    <link rel="stylesheet" href="../packages/lets-ui-tokens/dist/letsui.tokens.css" />
+    <link
+      rel="stylesheet"
+      href="../packages/lets-ui-tokens/dist/letsui.tokens.css"
+    />
     <link rel="stylesheet" href="../packages/styles/dist/letsui.css" />
-    <link rel="stylesheet" href="../node_modules/lets-ui-icons/dist/lets-ui-icons.css" />
+    <link
+      rel="stylesheet"
+      href="../node_modules/lets-ui-icons/dist/lets-ui-icons.css"
+    />
     <style>
       body {
         font-family: sans-serif;
@@ -41,15 +47,40 @@
     </style>
   </head>
   <body>
-    <!-- Modal: trigger padrão -->
+    <!-- Modal: trigger padrão + slot="actions" com <button> -->
     <section>
-      <h2>Modal — trigger padrão</h2>
+      <h2>Modal — slot="actions" com &lt;button&gt;</h2>
       <div class="row">
-        <lui-modal
-          title="Modal padrão"
-          body="Este modal usa o trigger interno gerado pelo componente."
-          trigger-label="Abrir modal"
-        ></lui-modal>
+        <lui-modal title="Modal padrão" trigger-label="Abrir modal">
+          <p>Este modal usa o trigger interno gerado pelo componente.</p>
+          <button
+            slot="actions"
+            data-modal-close
+            class="btn btn--secondary btn--lg"
+          >
+            Cancelar
+          </button>
+          <button slot="actions" class="btn btn--primary btn--lg">
+            Salvar
+          </button>
+        </lui-modal>
+      </div>
+    </section>
+
+    <!-- Modal: slot="actions" com <lui-button> -->
+    <section>
+      <h2>Modal — slot="actions" com &lt;lui-button&gt;</h2>
+      <div class="row">
+        <lui-modal title="Modal com lui-button" trigger-label="Abrir modal">
+          <p>As ações usam o componente <code>&lt;lui-button&gt;</code>.</p>
+          <lui-button
+            slot="actions"
+            data-modal-close
+            label="Cancelar"
+            variant="secondary"
+          ></lui-button>
+          <lui-button slot="actions" label="Salvar"></lui-button>
+        </lui-modal>
       </div>
     </section>
 
@@ -57,44 +88,80 @@
     <section>
       <h2>Modal — slot="trigger" customizado</h2>
       <div class="row">
-        <lui-modal title="Modal com trigger customizado" body="O trigger é qualquer elemento definido com slot=&quot;trigger&quot;.">
-          <button slot="trigger" class="btn btn--secondary btn--lg">
-            <i class="lui lui-settings" aria-hidden="true"></i>
-            Configurações
+        <lui-modal title="Modal com trigger customizado">
+          <lui-button
+            label="Configurar tudo"
+            size="lg"
+            variant="secondary"
+            slot="trigger"
+          ></lui-button>
+          <p>O trigger é qualquer elemento definido com slot="trigger".</p>
+          <button
+            slot="actions"
+            data-modal-close
+            class="btn btn--secondary btn--lg"
+          >
+            Cancelar
           </button>
-          <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancelar</button>
-          <button slot="actions" data-modal-close class="btn btn--primary btn--lg">Salvar</button>
+          <button slot="actions" class="btn btn--primary btn--lg">
+            Salvar
+          </button>
         </lui-modal>
 
-        <lui-modal title="Confirmar exclusão" body="Esta ação não pode ser desfeita.">
-          <button slot="trigger" class="btn btn--danger btn--lg">
-            <i class="lui lui-trash" aria-hidden="true"></i>
-            Excluir item
-          </button>
-          <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancelar</button>
-          <button slot="actions" data-modal-close class="btn btn--danger btn--lg">Excluir</button>
-        </lui-modal>
-
-        <lui-modal title="Informações" body="Acesse os detalhes do item selecionado.">
-          <button slot="trigger" class="icon-button icon-button--md" aria-label="Ver informações">
+        <lui-modal title="Informações">
+          <button
+            slot="trigger"
+            class="icon-button icon-button--md"
+            aria-label="Ver informações"
+          >
             <i class="lui lui-info-circle" aria-hidden="true"></i>
           </button>
+          <p>Acesse os detalhes do item selecionado.</p>
         </lui-modal>
       </div>
     </section>
 
-    <!-- Drawer: trigger padrão -->
+    <!-- Drawer: trigger padrão + slot="actions" com <button> -->
     <section>
-      <h2>Drawer — trigger padrão</h2>
+      <h2>Drawer — slot="actions" com &lt;button&gt;</h2>
       <div class="row">
         <lui-drawer
           title="Drawer padrão"
           trigger-label="Abrir drawer"
-          primary-button="Confirmar"
-          secondary-button="Cancelar"
           close-on-backdrop
         >
           <p>Conteúdo do drawer com trigger interno gerado pelo componente.</p>
+          <button
+            slot="actions"
+            data-drawer-close
+            class="btn btn--secondary btn--lg"
+          >
+            Cancelar
+          </button>
+          <button slot="actions" class="btn btn--primary btn--lg">
+            Confirmar
+          </button>
+        </lui-drawer>
+      </div>
+    </section>
+
+    <!-- Drawer: slot="actions" com <lui-button> -->
+    <section>
+      <h2>Drawer — slot="actions" com &lt;lui-button&gt;</h2>
+      <div class="row">
+        <lui-drawer
+          title="Drawer com lui-button"
+          trigger-label="Abrir drawer"
+          close-on-backdrop
+        >
+          <p>As ações usam o componente <code>&lt;lui-button&gt;</code>.</p>
+          <lui-button
+            slot="actions"
+            data-drawer-close
+            label="Cancelar"
+            variant="secondary"
+          ></lui-button>
+          <lui-button slot="actions" label="Confirmar"></lui-button>
         </lui-drawer>
       </div>
     </section>
@@ -103,28 +170,59 @@
     <section>
       <h2>Drawer — slot="trigger" customizado</h2>
       <div class="row">
-        <lui-drawer title="Filtros" primary-button="Aplicar" secondary-button="Limpar" close-on-backdrop>
+        <lui-drawer title="Filtros" close-on-backdrop>
           <button slot="trigger" class="btn btn--secondary btn--lg">
             <i class="lui lui-filter" aria-hidden="true"></i>
             Filtros
           </button>
           <p>Defina os filtros para refinar os resultados.</p>
+          <button
+            slot="actions"
+            data-drawer-close
+            class="btn btn--secondary btn--lg"
+          >
+            Limpar
+          </button>
+          <button slot="actions" class="btn btn--primary btn--lg">
+            Aplicar
+          </button>
         </lui-drawer>
 
         <lui-drawer title="Notificações" close-on-backdrop>
-          <button slot="trigger" class="icon-button icon-button--md" aria-label="Abrir notificações">
+          <button
+            slot="trigger"
+            class="icon-button icon-button--md"
+            aria-label="Abrir notificações"
+          >
             <i class="lui lui-bell" aria-hidden="true"></i>
           </button>
           <p>Você não tem notificações no momento.</p>
         </lui-drawer>
 
-        <lui-drawer title="Editar perfil" primary-button="Salvar" secondary-button="Cancelar" close-on-backdrop>
-          <lui-icon-button slot="trigger" label="Editar perfil" icon="pencil"></lui-icon-button>
+        <lui-drawer title="Editar perfil" close-on-backdrop>
+          <lui-icon-button
+            slot="trigger"
+            label="Editar perfil"
+            icon="pencil"
+          ></lui-icon-button>
           <p>Edite as informações do seu perfil.</p>
+          <button
+            slot="actions"
+            data-drawer-close
+            class="btn btn--secondary btn--lg"
+          >
+            Cancelar
+          </button>
+          <button slot="actions" class="btn btn--primary btn--lg">
+            Salvar
+          </button>
         </lui-drawer>
       </div>
     </section>
 
-    <script type="module" src="../packages/lets-ui-components/src/index.js"></script>
+    <script
+      type="module"
+      src="../packages/lets-ui-components/src/index.js"
+    ></script>
   </body>
 </html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -53,16 +53,6 @@
       <div class="row">
         <lui-modal title="Modal padrão" trigger-label="Abrir modal">
           <p>Este modal usa o trigger interno gerado pelo componente.</p>
-          <button
-            slot="actions"
-            data-modal-close
-            class="btn btn--secondary btn--lg"
-          >
-            Cancelar
-          </button>
-          <button slot="actions" class="btn btn--primary btn--lg">
-            Salvar
-          </button>
         </lui-modal>
       </div>
     </section>
@@ -170,7 +160,7 @@
     <section>
       <h2>Drawer — slot="trigger" customizado</h2>
       <div class="row">
-        <lui-drawer title="Filtros" close-on-backdrop>
+        <lui-drawer title="Filtros" close-on-backdrop size="sm">
           <button slot="trigger" class="btn btn--secondary btn--lg">
             <i class="lui lui-filter" aria-hidden="true"></i>
             Filtros
@@ -188,18 +178,7 @@
           </button>
         </lui-drawer>
 
-        <lui-drawer title="Notificações" close-on-backdrop>
-          <button
-            slot="trigger"
-            class="icon-button icon-button--md"
-            aria-label="Abrir notificações"
-          >
-            <i class="lui lui-bell" aria-hidden="true"></i>
-          </button>
-          <p>Você não tem notificações no momento.</p>
-        </lui-drawer>
-
-        <lui-drawer title="Editar perfil" close-on-backdrop>
+        <lui-drawer title="Editar perfil" close-on-backdrop size="xl">
           <lui-icon-button
             slot="trigger"
             label="Editar perfil"


### PR DESCRIPTION
## Summary

- **fix(drawer):** remove `box-shadow` do estado fechado para evitar que a sombra vaze na borda da viewport quando o painel está fora da tela (`translateX(100%)`)
- **feat(drawer):** adiciona variante `xl` (largura total, sem border-radius) e refatora os modificadores de tamanho para usar um mapa SCSS com border-radius responsivo
- **feat(modal):** adiciona botão de fechar (`icon-button` com `lui-x`) no header, espelhando o padrão do drawer

## Test plan

- [ ] Drawer fechado: confirmar que não aparece sombra na borda direita da tela
- [ ] Drawer `size="xl"`: ocupa 100% da largura sem border-radius
- [ ] Drawer `size="sm"`, `size="md"`, `size="lg"`: continuam funcionando normalmente
- [ ] Modal: botão X fecha o modal corretamente
- [ ] Modal: `aria-labelledby` ainda aponta para o título correto
- [ ] ESC e click no backdrop continuam fechando modal e drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)