### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["main"],
+  "labels": ["dependencies"],
+  "assignees": ["mateusvillain"],
+  "packageRules": [
+    {
+      "description": "Storybook — group all addons and core into one PR",
+      "groupName": "Storybook",
+      "matchPackageNames": [
+        "storybook",
+        "@storybook/**",
+        "@chromatic-com/storybook"
+      ]
+    },
+    {
+      "description": "Terrazzo — manual review required (beta packages)",
+      "matchPackageNames": ["@terrazzo/**"],
+      "groupName": "Terrazzo",
+      "stabilityDays": 7,
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "ESLint — group core and plugins together",
+      "groupName": "ESLint",
+      "matchPackageNames": ["eslint", "@eslint/**"]
+    },
+    {
+      "description": "Vitest — group runner and plugins together",
+      "groupName": "Vitest",
+      "matchPackageNames": ["vitest", "@vitest/**"]
+    },
+    {
+      "description": "Build tooling — PostCSS, Sass, cssnano",
+      "groupName": "Build tooling",
+      "matchPackageNames": ["postcss", "postcss-cli", "sass", "cssnano"]
+    },
+    {
+      "description": "Linting — Stylelint, Markdownlint, Prettier",
+      "groupName": "Linting",
+      "matchPackageNames": [
+        "prettier",
+        "stylelint",
+        "stylelint-config-standard-scss",
+        "stylelint-scss",
+        "markdownlint-cli2"
+      ]
+    },
+    {
+      "description": "GitHub Actions — update all workflow actions together",
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Skip workspace packages — managed internally via Changesets",
+      "matchPackageNames": ["@lets-ui/**"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `renovate.json` with `config:recommended` as base
- Group dependencies into logical PRs to avoid noise
- Apply 7-day stabilization window for `@terrazzo/**` (beta packages)
- Disable updates for internal `@lets-ui/**` packages — versioned by Changesets

## Dependency groups

| Group | Packages |
|---|---|
| Storybook | `storybook`, `@storybook/**`, `@chromatic-com/storybook` |
| Terrazzo | `@terrazzo/**` — 7-day stabilization |
| ESLint | `eslint`, `@eslint/**` |
| Vitest | `vitest`, `@vitest/**` |
| Build tooling | `postcss`, `postcss-cli`, `sass`, `cssnano` |
| Linting | `prettier`, `stylelint`, `stylelint-*`, `markdownlint-cli2` |
| GitHub Actions | all workflow actions |

## Test plan

- [x] Review `renovate.json` grouping rules
- [x] Enable the [Renovate GitHub App](https://github.com/apps/renovate) on the repository after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)