### PR TITLE
feat(typography): add lui-heading and lui-body components

### DIFF
--- a/.changeset/perky-ducks-cough.md
+++ b/.changeset/perky-ducks-cough.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+Add Heading and Body text components

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 .cache/
 .nyc_output/
 coverage/
+.claude
 
 *storybook.log
 storybook-static

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,15 +7,17 @@ const config = {
     '@chromatic-com/storybook',
     '@storybook/addon-vitest',
     '@storybook/addon-a11y',
-    '@storybook/addon-docs',
-  ],
-  framework: '@storybook/html-vite',
-  docs: {
-    mdxPluginOptions: {
-      mdxCompileOptions: {
-        remarkPlugins: [remarkGfm],
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        mdxPluginOptions: {
+          mdxCompileOptions: {
+            remarkPlugins: [remarkGfm],
+          },
+        },
       },
     },
-  },
+  ],
+  framework: '@storybook/html-vite',
 };
 export default config;

--- a/docs/components/Heading/Heading.stories.js
+++ b/docs/components/Heading/Heading.stories.js
@@ -57,9 +57,15 @@ const Template = ({
 
   const classes = [
     variant,
+<<<<<<< HEAD
     `text--color-${color}`,
     align && `text--align-${align}`,
     transform && transform !== '' && `text--transform-${transform}`,
+=======
+    `lui-heading--color-${color}`,
+    align && `typography--align-${align}`,
+    transform && transform !== '' && `typography--transform-${transform}`,
+>>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
   ]
     .filter(Boolean)
     .join(' ');
@@ -79,6 +85,7 @@ Heading.args = {
 };
 
 export const Display = () =>
+<<<<<<< HEAD
   `<div class="display text--color-heading">Display — O maior nível tipográfico</div>`;
 
 export const Title = () =>
@@ -108,32 +115,82 @@ export const AllVariants = () => `
     <h4 class="subheadline text--color-heading">Subheadline</h4>
     <h5 class="block-title text--color-heading">Block Title</h5>
     <h6 class="overtitle text--color-heading">Overtitle</h6>
+=======
+  `<div class="display lui-heading--color-heading">Display — O maior nível tipográfico</div>`;
+
+export const Title = () =>
+  `<h1 class="title lui-heading--color-heading">Title — Título principal da página</h1>`;
+
+export const Subtitle = () =>
+  `<h2 class="subtitle lui-heading--color-heading">Subtitle — Seção secundária</h2>`;
+
+export const HeadlineVariant = () =>
+  `<h3 class="headline lui-heading--color-heading">Headline — Destaque de conteúdo</h3>`;
+
+export const Subheadline = () =>
+  `<h4 class="subheadline lui-heading--color-heading">Subheadline — Sub-seção de conteúdo</h4>`;
+
+export const BlockTitle = () =>
+  `<h5 class="block-title lui-heading--color-heading">Block Title — Título de bloco</h5>`;
+
+export const Overtitle = () =>
+  `<h6 class="overtitle lui-heading--color-heading">Overtitle — Rótulo acima do título</h6>`;
+
+export const AllVariants = () => `
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <div class="display lui-heading--color-heading">Display</div>
+    <h1 class="title lui-heading--color-heading">Title</h1>
+    <h2 class="subtitle lui-heading--color-heading">Subtitle</h2>
+    <h3 class="headline lui-heading--color-heading">Headline</h3>
+    <h4 class="subheadline lui-heading--color-heading">Subheadline</h4>
+    <h5 class="block-title lui-heading--color-heading">Block Title</h5>
+    <h6 class="overtitle lui-heading--color-heading">Overtitle</h6>
+>>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
   </div>
 `;
 
 export const ColorVariants = () => `
   <div style="display: flex; flex-direction: column; gap: 8px;">
+<<<<<<< HEAD
     <h2 class="subtitle text--color-heading">Color: heading (default)</h2>
     <h2 class="subtitle text--color-body">Color: body</h2>
     <h2 class="subtitle text--color-caption">Color: caption</h2>
     <h2 class="subtitle text--color-error">Color: error</h2>
     <div style="background: var(--lui-color-neutral-bg-surface-neutral); padding: 8px; border-radius: 4px;">
       <h2 class="subtitle text--color-inverse">Color: inverse</h2>
+=======
+    <h2 class="subtitle lui-heading--color-heading">Color: heading (default)</h2>
+    <h2 class="subtitle lui-heading--color-body">Color: body</h2>
+    <h2 class="subtitle lui-heading--color-caption">Color: caption</h2>
+    <h2 class="subtitle lui-heading--color-error">Color: error</h2>
+    <div style="background: var(--lui-color-neutral-bg-surface-neutral); padding: 8px; border-radius: 4px;">
+      <h2 class="subtitle lui-heading--color-inverse">Color: inverse</h2>
+>>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
     </div>
   </div>
 `;
 
 export const Aligned = () => `
   <div style="display: flex; flex-direction: column; gap: 8px;">
+<<<<<<< HEAD
     <h2 class="subtitle text--color-heading text--align-left">Alinhamento à esquerda</h2>
     <h2 class="subtitle text--color-heading text--align-center">Alinhamento centralizado</h2>
     <h2 class="subtitle text--color-heading text--align-right">Alinhamento à direita</h2>
+=======
+    <h2 class="subtitle lui-heading--color-heading typography--align-left">Alinhamento à esquerda</h2>
+    <h2 class="subtitle lui-heading--color-heading typography--align-center">Alinhamento centralizado</h2>
+    <h2 class="subtitle lui-heading--color-heading typography--align-right">Alinhamento à direita</h2>
+>>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
   </div>
 `;
 
 export const WithLineClamp = () => `
   <h2
+<<<<<<< HEAD
     class="subtitle text--color-heading"
+=======
+    class="subtitle lui-heading--color-heading"
+>>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
     style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; max-width: 400px;"
   >
     Este texto é longo o suficiente para ser cortado em duas linhas. Quanto mais

--- a/docs/components/Heading/Heading.stories.js
+++ b/docs/components/Heading/Heading.stories.js
@@ -57,15 +57,9 @@ const Template = ({
 
   const classes = [
     variant,
-<<<<<<< HEAD
     `text--color-${color}`,
     align && `text--align-${align}`,
     transform && transform !== '' && `text--transform-${transform}`,
-=======
-    `lui-heading--color-${color}`,
-    align && `typography--align-${align}`,
-    transform && transform !== '' && `typography--transform-${transform}`,
->>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
   ]
     .filter(Boolean)
     .join(' ');
@@ -85,7 +79,6 @@ Heading.args = {
 };
 
 export const Display = () =>
-<<<<<<< HEAD
   `<div class="display text--color-heading">Display — O maior nível tipográfico</div>`;
 
 export const Title = () =>
@@ -115,82 +108,32 @@ export const AllVariants = () => `
     <h4 class="subheadline text--color-heading">Subheadline</h4>
     <h5 class="block-title text--color-heading">Block Title</h5>
     <h6 class="overtitle text--color-heading">Overtitle</h6>
-=======
-  `<div class="display lui-heading--color-heading">Display — O maior nível tipográfico</div>`;
-
-export const Title = () =>
-  `<h1 class="title lui-heading--color-heading">Title — Título principal da página</h1>`;
-
-export const Subtitle = () =>
-  `<h2 class="subtitle lui-heading--color-heading">Subtitle — Seção secundária</h2>`;
-
-export const HeadlineVariant = () =>
-  `<h3 class="headline lui-heading--color-heading">Headline — Destaque de conteúdo</h3>`;
-
-export const Subheadline = () =>
-  `<h4 class="subheadline lui-heading--color-heading">Subheadline — Sub-seção de conteúdo</h4>`;
-
-export const BlockTitle = () =>
-  `<h5 class="block-title lui-heading--color-heading">Block Title — Título de bloco</h5>`;
-
-export const Overtitle = () =>
-  `<h6 class="overtitle lui-heading--color-heading">Overtitle — Rótulo acima do título</h6>`;
-
-export const AllVariants = () => `
-  <div style="display: flex; flex-direction: column; gap: 16px;">
-    <div class="display lui-heading--color-heading">Display</div>
-    <h1 class="title lui-heading--color-heading">Title</h1>
-    <h2 class="subtitle lui-heading--color-heading">Subtitle</h2>
-    <h3 class="headline lui-heading--color-heading">Headline</h3>
-    <h4 class="subheadline lui-heading--color-heading">Subheadline</h4>
-    <h5 class="block-title lui-heading--color-heading">Block Title</h5>
-    <h6 class="overtitle lui-heading--color-heading">Overtitle</h6>
->>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
   </div>
 `;
 
 export const ColorVariants = () => `
   <div style="display: flex; flex-direction: column; gap: 8px;">
-<<<<<<< HEAD
     <h2 class="subtitle text--color-heading">Color: heading (default)</h2>
     <h2 class="subtitle text--color-body">Color: body</h2>
     <h2 class="subtitle text--color-caption">Color: caption</h2>
     <h2 class="subtitle text--color-error">Color: error</h2>
     <div style="background: var(--lui-color-neutral-bg-surface-neutral); padding: 8px; border-radius: 4px;">
       <h2 class="subtitle text--color-inverse">Color: inverse</h2>
-=======
-    <h2 class="subtitle lui-heading--color-heading">Color: heading (default)</h2>
-    <h2 class="subtitle lui-heading--color-body">Color: body</h2>
-    <h2 class="subtitle lui-heading--color-caption">Color: caption</h2>
-    <h2 class="subtitle lui-heading--color-error">Color: error</h2>
-    <div style="background: var(--lui-color-neutral-bg-surface-neutral); padding: 8px; border-radius: 4px;">
-      <h2 class="subtitle lui-heading--color-inverse">Color: inverse</h2>
->>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
     </div>
   </div>
 `;
 
 export const Aligned = () => `
   <div style="display: flex; flex-direction: column; gap: 8px;">
-<<<<<<< HEAD
     <h2 class="subtitle text--color-heading text--align-left">Alinhamento à esquerda</h2>
     <h2 class="subtitle text--color-heading text--align-center">Alinhamento centralizado</h2>
     <h2 class="subtitle text--color-heading text--align-right">Alinhamento à direita</h2>
-=======
-    <h2 class="subtitle lui-heading--color-heading typography--align-left">Alinhamento à esquerda</h2>
-    <h2 class="subtitle lui-heading--color-heading typography--align-center">Alinhamento centralizado</h2>
-    <h2 class="subtitle lui-heading--color-heading typography--align-right">Alinhamento à direita</h2>
->>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
   </div>
 `;
 
 export const WithLineClamp = () => `
   <h2
-<<<<<<< HEAD
     class="subtitle text--color-heading"
-=======
-    class="subtitle lui-heading--color-heading"
->>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
     style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; max-width: 400px;"
   >
     Este texto é longo o suficiente para ser cortado em duas linhas. Quanto mais

--- a/packages/lets-ui-components/src/components/body.js
+++ b/packages/lets-ui-components/src/components/body.js
@@ -4,8 +4,16 @@ const VALID_VARIANTS = ['lg', 'md', 'sm'];
 const VALID_ALIGNS = ['left', 'center', 'right', 'justify'];
 const VALID_TRANSFORMS = ['none', 'uppercase', 'lowercase', 'capitalize'];
 
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
 export class LuiBody extends HTMLElement {
   static observedAttributes = [
+    'label',
     'variant',
     'as',
     'align',
@@ -17,27 +25,11 @@ export class LuiBody extends HTMLElement {
   ];
 
   connectedCallback() {
-    if (this._initialized) return;
-    this._initialized = true;
-
-    queueMicrotask(() => {
-      this._captureContent();
-      this.render();
-    });
+    this.render();
   }
 
   attributeChangedCallback() {
-    if (this._initialized) this.render();
-  }
-
-  _captureContent() {
-    if (this._contentCaptured) return;
-    this._contentHtml = Array.from(this.childNodes)
-      .map((node) =>
-        node.nodeType === Node.TEXT_NODE ? node.textContent : node.outerHTML
-      )
-      .join('');
-    this._contentCaptured = true;
+    this.render();
   }
 
   render() {
@@ -50,6 +42,7 @@ export class LuiBody extends HTMLElement {
     const color = this.getAttribute('color') ?? 'body';
     const italic = hasBooleanAttribute(this, 'italic');
     const underline = hasBooleanAttribute(this, 'underline');
+    const label = escapeHtml(this.getAttribute('label') ?? '');
 
     const classes = [
       `body--${variant}`,
@@ -66,9 +59,6 @@ export class LuiBody extends HTMLElement {
       ? ` style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: ${lineClamp}; -webkit-box-orient: vertical;"`
       : '';
 
-    mountMarkup(
-      this,
-      `<${as} class="${classes}"${styleAttr}>${this._contentHtml ?? ''}</${as}>`
-    );
+    mountMarkup(this, `<${as} class="${classes}"${styleAttr}>${label}</${as}>`);
   }
 }

--- a/packages/lets-ui-components/src/components/heading.js
+++ b/packages/lets-ui-components/src/components/heading.js
@@ -14,8 +14,16 @@ const VALID_VARIANTS = Object.keys(DEFAULT_TAGS);
 const VALID_ALIGNS = ['left', 'center', 'right', 'justify'];
 const VALID_TRANSFORMS = ['none', 'uppercase', 'lowercase', 'capitalize'];
 
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
 export class LuiHeading extends HTMLElement {
   static observedAttributes = [
+    'label',
     'variant',
     'as',
     'align',
@@ -25,27 +33,11 @@ export class LuiHeading extends HTMLElement {
   ];
 
   connectedCallback() {
-    if (this._initialized) return;
-    this._initialized = true;
-
-    queueMicrotask(() => {
-      this._captureContent();
-      this.render();
-    });
+    this.render();
   }
 
   attributeChangedCallback() {
-    if (this._initialized) this.render();
-  }
-
-  _captureContent() {
-    if (this._contentCaptured) return;
-    this._contentHtml = Array.from(this.childNodes)
-      .map((node) =>
-        node.nodeType === Node.TEXT_NODE ? node.textContent : node.outerHTML
-      )
-      .join('');
-    this._contentCaptured = true;
+    this.render();
   }
 
   render() {
@@ -56,6 +48,7 @@ export class LuiHeading extends HTMLElement {
     const lineClamp = parseInt(this.getAttribute('line-clamp'), 10) || null;
     const transform = this.getAttribute('transform');
     const color = this.getAttribute('color') ?? 'heading';
+    const label = escapeHtml(this.getAttribute('label') ?? '');
 
     const classes = [
       variant,
@@ -70,9 +63,6 @@ export class LuiHeading extends HTMLElement {
       ? ` style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: ${lineClamp}; -webkit-box-orient: vertical;"`
       : '';
 
-    mountMarkup(
-      this,
-      `<${as} class="${classes}"${styleAttr}>${this._contentHtml ?? ''}</${as}>`
-    );
+    mountMarkup(this, `<${as} class="${classes}"${styleAttr}>${label}</${as}>`);
   }
 }

--- a/packages/lets-ui-components/src/index.js
+++ b/packages/lets-ui-components/src/index.js
@@ -36,7 +36,10 @@ function define(name, elementClass) {
 define('lui-alert', LuiAlert);
 define('lui-body', LuiBody);
 define('lui-heading', LuiHeading);
+<<<<<<< HEAD
 define('lui-image', LuiImage);
+=======
+>>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
 define('lui-drawer', LuiDrawer);
 define('lui-tabs', LuiTabs);
 define('lui-tab', LuiTab);

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -263,85 +263,85 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
       import '@lets-ui/components';
     </script>
   </body>
+
+  <style is:global>
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      background: var(--color-bg-surface-neutral, #f5f5f5);
+      color: var(--color-text-body, #1a1a1a);
+    }
+
+    code {
+      font-family: monospace;
+      background: var(--color-bg-container-neutral, #e8e8e8);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.875em;
+    }
+
+    .pg-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 16px 32px;
+      border-bottom: 1px solid var(--color-border-neutral, #e0e0e0);
+      background: var(--color-bg-surface-primary, #fff);
+    }
+
+    .pg-header__logo {
+      font-weight: 700;
+      font-size: 1rem;
+    }
+
+    .pg-header__label {
+      font-size: 0.75rem;
+      opacity: 0.5;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .pg-main {
+      display: flex;
+      flex-direction: column;
+      gap: 48px;
+      padding: 48px 32px;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    .pg-section {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .pg-section__title {
+      margin: 0;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.5;
+    }
+
+    .pg-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .pg-col {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+  </style>
 </html>
-
-<style is:global>
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-
-  body {
-    margin: 0;
-    font-family: sans-serif;
-    background: var(--color-bg-surface-neutral, #f5f5f5);
-    color: var(--color-text-body, #1a1a1a);
-  }
-
-  code {
-    font-family: monospace;
-    background: var(--color-bg-container-neutral, #e8e8e8);
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-size: 0.875em;
-  }
-
-  .pg-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 32px;
-    border-bottom: 1px solid var(--color-border-neutral, #e0e0e0);
-    background: var(--color-bg-surface-primary, #fff);
-  }
-
-  .pg-header__logo {
-    font-weight: 700;
-    font-size: 1rem;
-  }
-
-  .pg-header__label {
-    font-size: 0.75rem;
-    opacity: 0.5;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-  }
-
-  .pg-main {
-    display: flex;
-    flex-direction: column;
-    gap: 48px;
-    padding: 48px 32px;
-    max-width: 960px;
-    margin: 0 auto;
-  }
-
-  .pg-section {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-  }
-
-  .pg-section__title {
-    margin: 0;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    opacity: 0.5;
-  }
-
-  .pg-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    align-items: center;
-  }
-
-  .pg-col {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-</style>

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -22,29 +22,35 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
       <section class="pg-section">
         <h2 class="pg-section__title">Heading</h2>
         <div class="pg-col">
-          <lui-heading variant="display">Display — Escala máxima</lui-heading>
-          <lui-heading variant="title">Title — h1</lui-heading>
-          <lui-heading variant="subtitle">Subtitle — h2</lui-heading>
-          <lui-heading variant="headline">Heading — h3</lui-heading>
-          <lui-heading variant="subheadline">Subheadline — h4</lui-heading>
-          <lui-heading variant="block-title">Block Title — h5</lui-heading>
-          <lui-heading variant="overtitle">Overtitle — h6</lui-heading>
+          <lui-heading variant="display" label="Display — Escala máxima"
+          ></lui-heading>
+          <lui-heading variant="title" label="Title — h1"></lui-heading>
+          <lui-heading variant="subtitle" label="Subtitle — h2"></lui-heading>
+          <lui-heading variant="headline" label="Heading — h3"></lui-heading>
+          <lui-heading variant="subheadline" label="Subheadline — h4"
+          ></lui-heading>
+          <lui-heading variant="block-title" label="Block Title — h5"
+          ></lui-heading>
+          <lui-heading variant="overtitle" label="Overtitle — h6"></lui-heading>
         </div>
         <div class="pg-col">
-          <lui-heading variant="subtitle" color="caption" align="center"
-            >Subtitle · color caption · align center</lui-heading
-          >
-          <lui-heading variant="subtitle" color="error" transform="uppercase"
-            >Subtitle · color error · transform uppercase</lui-heading
-          >
+          <lui-heading
+            variant="subtitle"
+            color="caption"
+            align="center"
+            label="Subtitle · color caption · align center"></lui-heading>
+          <lui-heading
+            variant="subtitle"
+            color="error"
+            transform="uppercase"
+            label="Subtitle · color error · transform uppercase"></lui-heading>
           <lui-heading
             variant="title"
             line-clamp="1"
             as="p"
             style="max-width: 400px;"
-            >Line-clamp 1 · as p · Lorem ipsum dolor sit amet consectetur
-            adipiscing elit</lui-heading
-          >
+            label="Line-clamp 1 · as p · Lorem ipsum dolor sit amet consectetur adipiscing elit"
+          ></lui-heading>
         </div>
       </section>
 
@@ -52,30 +58,34 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
       <section class="pg-section">
         <h2 class="pg-section__title">Body</h2>
         <div class="pg-col">
-          <lui-body variant="lg"
-            >Large — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</lui-body
-          >
-          <lui-body variant="md"
-            >Medium — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</lui-body
-          >
-          <lui-body variant="sm"
-            >Small — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</lui-body
-          >
+          <lui-body
+            variant="lg"
+            label="Large — Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          ></lui-body>
+          <lui-body
+            variant="md"
+            label="Medium — Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          ></lui-body>
+          <lui-body
+            variant="sm"
+            label="Small — Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          ></lui-body>
         </div>
         <div class="pg-col">
-          <lui-body variant="md" color="caption">Color caption</lui-body>
-          <lui-body variant="md" italic>Itálico</lui-body>
-          <lui-body variant="md" underline>Sublinhado</lui-body>
-          <lui-body variant="md" italic underline>Itálico + sublinhado</lui-body
-          >
-          <lui-body variant="md" line-clamp="1" style="max-width: 400px;"
-            >Line-clamp 2 — texto longo para demonstrar o corte: Lorem ipsum
-            dolor sit amet consectetur adipiscing elit sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua.</lui-body
-          >
-          <lui-body variant="md" align="center"
-            >Alinhamento centralizado</lui-body
-          >
+          <lui-body variant="md" color="caption" label="Color caption"
+          ></lui-body>
+          <lui-body variant="md" italic label="Itálico"></lui-body>
+          <lui-body variant="md" underline label="Sublinhado"></lui-body>
+          <lui-body variant="md" italic underline label="Itálico + sublinhado"
+          ></lui-body>
+          <lui-body
+            variant="md"
+            line-clamp="1"
+            style="max-width: 400px;"
+            label="Line-clamp 2 — texto longo para demonstrar o corte: Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+          ></lui-body>
+          <lui-body variant="md" align="center" label="Alinhamento centralizado"
+          ></lui-body>
         </div>
       </section>
 
@@ -245,104 +255,6 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
               variant="secondary"></lui-button>
             <lui-button slot="actions" label="Salvar"></lui-button>
           </lui-drawer>
-        </div>
-      </section>
-
-      <!-- ── Image ─────────────────────────────────────────── -->
-      <section class="pg-section">
-        <h2 class="pg-section__title">Image</h2>
-        <lui-image
-          src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-          alt="Mountain landscape at sunset"
-          fill="80px"
-        >
-        </lui-image>
-        <div>
-          <lui-image
-            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-            alt="Mountain landscape at sunset"
-            width="320px"
-            aspect-ratio="16 / 9"
-            radius="md"
-            fit="cover"
-            loading="eager"
-          >
-          </lui-image>
-        </div>
-        <div>
-          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-            Square · radius circle
-          </p>
-          <lui-image
-            src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80"
-            alt="Portrait photo"
-            width="120px"
-            aspect-ratio="1 / 1"
-            radius="circle"
-            fit="cover"
-            loading="eager"
-          >
-          </lui-image>
-        </div>
-        <div>
-          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-            Fit contain · radius sm
-          </p>
-          <lui-image
-            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-            alt="Contain fit"
-            width="200px"
-            height="150px"
-            fit="contain"
-            radius="sm"
-            loading="eager"
-          >
-          </lui-image>
-        </div>
-        <div>
-          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-            Broken src · error state (CSS fallback)
-          </p>
-          <lui-image
-            src="https://invalid.example.com/broken.jpg"
-            alt="Broken image"
-            width="200px"
-            aspect-ratio="16 / 9"
-            radius="md"
-            loading="eager"
-          >
-          </lui-image>
-        </div>
-        <div>
-          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-            Broken src · fallback-src manual
-          </p>
-          <lui-image
-            src="https://invalid.example.com/broken.jpg"
-            alt="Imagem com fallback manual"
-            width="200px"
-            aspect-ratio="16 / 9"
-            radius="md"
-            fallback-src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-            loading="eager"
-          >
-          </lui-image>
-        </div>
-        <div>
-          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-            Com caption (figure)
-          </p>
-          <lui-image
-            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-            alt="Mountain landscape"
-            width="280px"
-            aspect-ratio="4 / 3"
-            radius="md"
-            fit="cover"
-            loading="eager"
-            caption="Foto: Unsplash — montanhas ao pôr do sol"
-          >
-          </lui-image>
         </div>
       </section>
     </main>

--- a/packages/playground/src/pages/vanillacomponents.astro
+++ b/packages/playground/src/pages/vanillacomponents.astro
@@ -43,885 +43,913 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
   </head>
   <body>
     <section class="section-container">
-      <!-- Typography — Heading -->
       <div style="display: flex; flex-direction: column; gap: 12px;">
-        <div class="display lui-heading--color-heading">Display — Escala máxima</div>
+        <div class="display lui-heading--color-heading">
+          Display — Escala máxima
+        </div>
         <h1 class="title lui-heading--color-heading">Title — h1</h1>
         <h2 class="subtitle lui-heading--color-heading">Subtitle — h2</h2>
         <h3 class="headline lui-heading--color-heading">Headline — h3</h3>
         <h4 class="subheadline lui-heading--color-heading">Subheadline — h4</h4>
         <h5 class="block-title lui-heading--color-heading">Block Title — h5</h5>
         <h6 class="overtitle lui-heading--color-heading">Overtitle — h6</h6>
-        <h2 class="subtitle lui-heading--color-caption typography--align-center">Subtitle centralizado + color caption</h2>
-        <h2 class="subtitle lui-heading--color-error typography--transform-uppercase">Subtitle uppercase + color error</h2>
-      </div>
-
-      <!-- Typography — Body -->
-      <div style="display: flex; flex-direction: column; gap: 12px;">
-        <p class="body--lg lui-body--color-body">Large — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        <p class="body--md lui-body--color-body">Medium — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        <p class="body--sm lui-body--color-body">Small — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        <p class="body--md lui-body--color-caption">Color caption</p>
-        <p class="body--md lui-body--color-body lui-body--italic">Itálico</p>
-        <p class="body--md lui-body--color-body lui-body--underline">Sublinhado</p>
-        <p class="body--md lui-body--color-body lui-body--italic lui-body--underline">Itálico + sublinhado</p>
-        <p
-          class="body--md lui-body--color-body"
-          style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; max-width: 400px;"
+        <h2
+          class="subtitle lui-heading--color-caption typography--align-center"
         >
-          Line clamp em 2 linhas — texto longo para demonstrar o corte: Lorem ipsum dolor sit amet
-          consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </p>
-      </div>
+          Subtitle centralizado + color caption
+        </h2>
+        <h2
+          class="subtitle lui-heading--color-error typography--transform-uppercase"
+        >
+          Subtitle uppercase + color error
+        </h2>
 
-      <br />
-      <br />
-
-      <a href="playground.html" class="link">Link</a>
-
-      <button id="btnPrimary" class="btn btn--primary btn--lg">
-        Botão primário
-      </button>
-
-      <button id="btnDanger" class="btn btn--danger btn--lg">
-        Botão primário
-      </button>
-
-      <div class="alert alert--success" role="alert">
-        <div class="alert__content">
-          <div class="alert__text">
-            <p class="body--lg">Alert title</p>
-            <p class="body--lg">Descriptions</p>
-          </div>
-        </div>
-
-        <div class="alert__actions">
-          <button class="btn btn--secondary btn--lg">Cancelar</button>
-          <button class="btn btn--primary btn--lg">Confirmar</button>
-        </div>
-      </div>
-
-      <label class="checkbox checkbox--lg">
-        <input id="check" type="checkbox" />
-        <span>Aceito os termos</span>
-      </label>
-
-      <label class="radio radio--lg">
-        <input type="radio" name="demo-html" value="opt1" checked />
-        <span>Opção 1</span>
-      </label>
-      <label class="radio radio--lg">
-        <input type="radio" name="demo-html" value="opt2" />
-        <span>Opção 2</span>
-      </label>
-      <label class="radio radio--lg">
-        <input type="radio" name="demo-html" value="opt3" disabled />
-        <span>Opção 3 (desabilitado)</span>
-      </label>
-
-      <label class="switch switch--lg">
-        <input type="checkbox" role="switch" checked />
-        <span>Receber notificações</span>
-      </label>
-      <label class="switch switch--lg">
-        <input type="checkbox" role="switch" />
-        <span>Modo escuro</span>
-      </label>
-      <label class="switch switch--lg">
-        <input type="checkbox" role="switch" checked disabled />
-        <span>Ativado e desabilitado</span>
-      </label>
-      <label class="switch switch--md">
-        <input type="checkbox" role="switch" checked />
-        <span>Tamanho médio</span>
-      </label>
-
-      <div class="form__group form__lg">
-        <label for="select">Escolha uma opção</label>
-        <select id="select">
-          <option selected>Option 1</option>
-          <option>Option 2</option>
-          <option>Option 3</option>
-        </select>
-      </div>
-
-      <div class="native-select native-select--lg">
-        <div class="native-select__head">
-          <div class="native-select__label-wrap">
-            <label for="lui-select-14-input">Select</label>
-            <span class="native-select__optional">(opcional)</span>
-          </div>
-        </div>
-        <div class="native-select__control">
-          <select
-            class="native-select__input"
-            id="lui-select-14-input"
-            aria-label="Label"
-            aria-describedby="lui-select-14-message"
+        <!-- Typography — Body -->
+        <div style="display: flex; flex-direction: column; gap: 12px;">
+          <p class="body--lg lui-body--color-body">
+            Large — Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </p>
+          <p class="body--md lui-body--color-body">
+            Medium — Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </p>
+          <p class="body--sm lui-body--color-body">
+            Small — Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </p>
+          <p class="body--md lui-body--color-caption">Color caption</p>
+          <p class="body--md lui-body--color-body lui-body--italic">Itálico</p>
+          <p class="body--md lui-body--color-body lui-body--underline">
+            Sublinhado
+          </p>
+          <p
+            class="body--md lui-body--color-body lui-body--italic lui-body--underline"
           >
-            <option value="" disabled="" hidden="">Select an option</option>
-            <option value="Option 1" selected="">Option 1</option>
-            <option value="Option 2">Option 2</option>
-            <option value="Option 3">Option 3</option>
+            Itálico + sublinhado
+          </p>
+          <p
+            class="body--md lui-body--color-body"
+            style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; max-width: 400px;"
+          >
+            Line clamp em 2 linhas — texto longo para demonstrar o corte: Lorem
+            ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua.
+          </p>
+        </div>
+
+        <br />
+        <br />
+
+        <a href="playground.html" class="link">Link</a>
+
+        <button id="btnPrimary" class="btn btn--primary btn--lg">
+          Botão primário
+        </button>
+
+        <button id="btnDanger" class="btn btn--danger btn--lg">
+          Botão primário
+        </button>
+
+        <div class="alert alert--success" role="alert">
+          <div class="alert__content">
+            <div class="alert__text">
+              <p class="body--lg">Alert title</p>
+              <p class="body--lg">Descriptions</p>
+            </div>
+          </div>
+
+          <div class="alert__actions">
+            <button class="btn btn--secondary btn--lg">Cancelar</button>
+            <button class="btn btn--primary btn--lg">Confirmar</button>
+          </div>
+        </div>
+
+        <label class="checkbox checkbox--lg">
+          <input id="check" type="checkbox" />
+          <span>Aceito os termos</span>
+        </label>
+
+        <label class="radio radio--lg">
+          <input type="radio" name="demo-html" value="opt1" checked />
+          <span>Opção 1</span>
+        </label>
+        <label class="radio radio--lg">
+          <input type="radio" name="demo-html" value="opt2" />
+          <span>Opção 2</span>
+        </label>
+        <label class="radio radio--lg">
+          <input type="radio" name="demo-html" value="opt3" disabled />
+          <span>Opção 3 (desabilitado)</span>
+        </label>
+
+        <label class="switch switch--lg">
+          <input type="checkbox" role="switch" checked />
+          <span>Receber notificações</span>
+        </label>
+        <label class="switch switch--lg">
+          <input type="checkbox" role="switch" />
+          <span>Modo escuro</span>
+        </label>
+        <label class="switch switch--lg">
+          <input type="checkbox" role="switch" checked disabled />
+          <span>Ativado e desabilitado</span>
+        </label>
+        <label class="switch switch--md">
+          <input type="checkbox" role="switch" checked />
+          <span>Tamanho médio</span>
+        </label>
+
+        <div class="form__group form__lg">
+          <label for="select">Escolha uma opção</label>
+          <select id="select">
+            <option selected>Option 1</option>
+            <option>Option 2</option>
+            <option>Option 3</option>
           </select>
-          <span class="native-select__arrow" aria-hidden="true">
-            <svg viewBox="0 0 14 7" focusable="false">
-              <path d="M1 1L7 6L13 1"></path>
-            </svg>
-          </span>
         </div>
-        <p id="lui-select-14-message" class="native-select__message">
-          Hint text
-        </p>
-      </div>
 
-      <div class="input-field input-field--lg">
-        <div class="input-field__head">
-          <div class="input-field__label-wrap">
-            <label for="field">Nome</label>
+        <div class="native-select native-select--lg">
+          <div class="native-select__head">
+            <div class="native-select__label-wrap">
+              <label for="lui-select-14-input">Select</label>
+              <span class="native-select__optional">(opcional)</span>
+            </div>
+          </div>
+          <div class="native-select__control">
+            <select
+              class="native-select__input"
+              id="lui-select-14-input"
+              aria-label="Label"
+              aria-describedby="lui-select-14-message"
+            >
+              <option value="" disabled="" hidden="">Select an option</option>
+              <option value="Option 1" selected="">Option 1</option>
+              <option value="Option 2">Option 2</option>
+              <option value="Option 3">Option 3</option>
+            </select>
+            <span class="native-select__arrow" aria-hidden="true">
+              <svg viewBox="0 0 14 7" focusable="false">
+                <path d="M1 1L7 6L13 1"></path>
+              </svg>
+            </span>
+          </div>
+          <p id="lui-select-14-message" class="native-select__message">
+            Hint text
+          </p>
+        </div>
+
+        <div class="input-field input-field--lg">
+          <div class="input-field__head">
+            <div class="input-field__label-wrap">
+              <label for="field">Nome</label>
+            </div>
+          </div>
+          <div class="input-field__control">
+            <input
+              id="field"
+              class="input-field__input"
+              type="text"
+              maxlength="100"
+              placeholder="Placeholder"
+              aria-describedby="fieldHint"
+            />
           </div>
         </div>
-        <div class="input-field__control">
-          <input
-            id="field"
-            class="input-field__input"
-            type="text"
-            maxlength="100"
-            placeholder="Placeholder"
-            aria-describedby="fieldHint"
-          />
-        </div>
-      </div>
 
-      <div
-        class="input-field input-field--lg input-field--error input-field--with-icon input-field--with-prefix input-field--with-suffix"
-      >
-        <div class="input-field__head">
-          <div class="input-field__label-wrap">
-            <label for="fieldError">Label</label>
+        <div
+          class="input-field input-field--lg input-field--error input-field--with-icon input-field--with-prefix input-field--with-suffix"
+        >
+          <div class="input-field__head">
+            <div class="input-field__label-wrap">
+              <label for="fieldError">Label</label>
+            </div>
+            <span class="input-field__counter">0/100</span>
           </div>
-          <span class="input-field__counter">0/100</span>
-        </div>
 
-        <div class="input-field__control">
-          <span class="input-field__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false">
-              <path
-                d="M12 2.25L14.78 7.88L21 8.79L16.5 13.18L17.56 19.38L12 16.46L6.44 19.38L7.5 13.18L3 8.79L9.22 7.88L12 2.25Z"
-              ></path>
-            </svg>
-          </span>
-          <span class="input-field__prefix">www.</span>
-          <input
-            id="fieldError"
-            class="input-field__input"
-            type="text"
-            maxlength="100"
-            placeholder="Placeholder"
-            aria-describedby="fieldErrorText"
-          />
-          <span class="input-field__suffix">.com</span>
-        </div>
-
-        <p id="fieldErrorText" class="input-field__message">
-          Campo obrigatório.
-        </p>
-      </div>
-
-      <div class="textarea-field textarea-field--lg">
-        <div class="textarea-field__head">
-          <div class="textarea-field__label-wrap">
-            <label for="textarea-1">Descrição</label>
-            <span class="textarea-field__optional">(opcional)</span>
+          <div class="input-field__control">
+            <span class="input-field__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path
+                  d="M12 2.25L14.78 7.88L21 8.79L16.5 13.18L17.56 19.38L12 16.46L6.44 19.38L7.5 13.18L3 8.79L9.22 7.88L12 2.25Z"
+                ></path>
+              </svg>
+            </span>
+            <span class="input-field__prefix">www.</span>
+            <input
+              id="fieldError"
+              class="input-field__input"
+              type="text"
+              maxlength="100"
+              placeholder="Placeholder"
+              aria-describedby="fieldErrorText"
+            />
+            <span class="input-field__suffix">.com</span>
           </div>
-          <span class="textarea-field__counter">0/200</span>
-        </div>
-        <label class="textarea-field__control" for="textarea-1">
-          <textarea
-            class="textarea-field__input"
-            id="textarea-1"
-            placeholder="Escreva uma descrição..."
-            rows="4"
-            maxlength="200"></textarea>
-        </label>
-        <p class="textarea-field__message">Hint text</p>
-      </div>
 
-      <div class="textarea-field textarea-field--lg textarea-field--error">
-        <div class="textarea-field__head">
-          <div class="textarea-field__label-wrap">
-            <label for="textarea-2">Observações</label>
+          <p id="fieldErrorText" class="input-field__message">
+            Campo obrigatório.
+          </p>
+        </div>
+
+        <div class="textarea-field textarea-field--lg">
+          <div class="textarea-field__head">
+            <div class="textarea-field__label-wrap">
+              <label for="textarea-1">Descrição</label>
+              <span class="textarea-field__optional">(opcional)</span>
+            </div>
+            <span class="textarea-field__counter">0/200</span>
           </div>
+          <label class="textarea-field__control" for="textarea-1">
+            <textarea
+              class="textarea-field__input"
+              id="textarea-1"
+              placeholder="Escreva uma descrição..."
+              rows="4"
+              maxlength="200"></textarea>
+          </label>
+          <p class="textarea-field__message">Hint text</p>
         </div>
-        <label class="textarea-field__control" for="textarea-2">
-          <textarea
-            class="textarea-field__input"
-            id="textarea-2"
-            placeholder="Escreva suas observações..."
-            rows="4"
-            aria-describedby="textarea-2-msg"></textarea>
-        </label>
-        <p id="textarea-2-msg" class="textarea-field__message">
-          Campo obrigatório.
-        </p>
-      </div>
 
-      <div class="textarea-field textarea-field--lg textarea-field--disabled">
-        <div class="textarea-field__head">
-          <div class="textarea-field__label-wrap">
-            <label for="textarea-3">Comentário</label>
+        <div class="textarea-field textarea-field--lg textarea-field--error">
+          <div class="textarea-field__head">
+            <div class="textarea-field__label-wrap">
+              <label for="textarea-2">Observações</label>
+            </div>
           </div>
+          <label class="textarea-field__control" for="textarea-2">
+            <textarea
+              class="textarea-field__input"
+              id="textarea-2"
+              placeholder="Escreva suas observações..."
+              rows="4"
+              aria-describedby="textarea-2-msg"></textarea>
+          </label>
+          <p id="textarea-2-msg" class="textarea-field__message">
+            Campo obrigatório.
+          </p>
         </div>
-        <label class="textarea-field__control" for="textarea-3">
-          <textarea
-            class="textarea-field__input"
-            id="textarea-3"
-            rows="4"
-            disabled
-            aria-disabled="true">Conteúdo somente leitura.</textarea
-          >
-        </label>
-      </div>
 
-      <span class="tag-md tag--md tag--surface-primary">Tag</span>
+        <div class="textarea-field textarea-field--lg textarea-field--disabled">
+          <div class="textarea-field__head">
+            <div class="textarea-field__label-wrap">
+              <label for="textarea-3">Comentário</label>
+            </div>
+          </div>
+          <label class="textarea-field__control" for="textarea-3">
+            <textarea
+              class="textarea-field__input"
+              id="textarea-3"
+              rows="4"
+              disabled
+              aria-disabled="true">Conteúdo somente leitura.</textarea
+            >
+          </label>
+        </div>
 
-      <a class="link" href="#">Abrir detalhe</a>
+        <span class="tag-md tag--md tag--surface-primary">Tag</span>
 
-      <nav aria-label="Breadcrumb">
-        <ul class="breadcrumb" role="list">
-          <li><a class="link" href="/">Home</a></li>
-          <li><a class="link" href="/produtos">Produtos</a></li>
-          <li aria-current="page">Notebook</li>
-        </ul>
-      </nav>
+        <a class="link" href="#">Abrir detalhe</a>
 
-      <div
-        style="
+        <nav aria-label="Breadcrumb">
+          <ul class="breadcrumb" role="list">
+            <li><a class="link" href="/">Home</a></li>
+            <li><a class="link" href="/produtos">Produtos</a></li>
+            <li aria-current="page">Notebook</li>
+          </ul>
+        </nav>
+
+        <div
+          style="
           display: grid;
           grid-template-columns: repeat(2, minmax(0, 1fr));
           gap: 16px;
           width: fit-content;
           align-items: center;
         "
-      >
-        <span class="tooltip tooltip--top">
-          <button
-            type="button"
-            class="tooltip__trigger btn btn--primary btn--lg"
-          >
-            Hover/Focus top
-          </button>
-          <span class="tooltip__content" role="tooltip">
-            Tooltip no botão nativo
+        >
+          <span class="tooltip tooltip--top">
+            <button
+              type="button"
+              class="tooltip__trigger btn btn--primary btn--lg"
+            >
+              Hover/Focus top
+            </button>
+            <span class="tooltip__content" role="tooltip">
+              Tooltip no botão nativo
+            </span>
           </span>
-        </span>
 
-        <span class="tooltip tooltip--right">
-          <button
-            type="button"
-            class="tooltip__trigger btn btn--secondary btn--md"
-          >
-            Hover/Focus right
-          </button>
-          <span class="tooltip__content" role="tooltip">
-            Tooltip right com texto maior para validar que o conteúdo aparece
-            completo sem corte.
+          <span class="tooltip tooltip--right">
+            <button
+              type="button"
+              class="tooltip__trigger btn btn--secondary btn--md"
+            >
+              Hover/Focus right
+            </button>
+            <span class="tooltip__content" role="tooltip">
+              Tooltip right com texto maior para validar que o conteúdo aparece
+              completo sem corte.
+            </span>
           </span>
-        </span>
 
-        <span class="tooltip tooltip--left">
+          <span class="tooltip tooltip--left">
+            <button
+              class="tooltip__trigger icon-button icon-button--md"
+              aria-label="Informações"
+            >
+              <i class="lui lui-info-circle" aria-hidden="true"></i>
+            </button>
+            <span class="tooltip__content" role="tooltip">
+              Tooltip no icon-button
+            </span>
+          </span>
+
+          <span class="tooltip tooltip--bottom">
+            <a class="tooltip__trigger link" href="#">Hover/Focus bottom</a>
+            <span class="tooltip__content" role="tooltip">
+              Tooltip bottom com texto longo para conferir animação de cima para
+              baixo e leitura completa.
+            </span>
+          </span>
+        </div>
+
+        <!-- Icon Button — exemplos -->
+        <div
+          style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;"
+        >
+          <button class="icon-button icon-button--lg" aria-label="Confirmar">
+            <i class="lui lui-check" aria-hidden="true"></i>
+          </button>
+          <button class="icon-button icon-button--lg" aria-label="Excluir">
+            <i class="lui lui-trash" aria-hidden="true"></i>
+          </button>
+          <button class="icon-button icon-button--lg" aria-label="Fechar">
+            <i class="lui lui-x" aria-hidden="true"></i>
+          </button>
+          <button class="icon-button icon-button--lg" aria-label="Informações">
+            <i class="lui lui-info-circle" aria-hidden="true"></i>
+          </button>
+          <button class="icon-button icon-button--lg" aria-label="Avançar">
+            <i class="lui lui-caret-right" aria-hidden="true"></i>
+          </button>
+          <button class="icon-button icon-button--lg" aria-label="Mais opções">
+            <i class="lui lui-dots-three" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div
+          style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;"
+        >
           <button
-            class="tooltip__trigger icon-button icon-button--md"
-            aria-label="Informações"
+            class="icon-button icon-button--lg"
+            aria-label="Confirmar (solid)"
+          >
+            <i class="lui-solid lui-check" aria-hidden="true"></i>
+          </button>
+          <button
+            class="icon-button icon-button--lg"
+            aria-label="Excluir (solid)"
+          >
+            <i class="lui-solid lui-trash" aria-hidden="true"></i>
+          </button>
+          <button
+            class="icon-button icon-button--lg"
+            aria-label="Fechar (solid)"
+          >
+            <i class="lui-solid lui-x" aria-hidden="true"></i>
+          </button>
+          <button
+            class="icon-button icon-button--md"
+            aria-label="Informações (md)"
           >
             <i class="lui lui-info-circle" aria-hidden="true"></i>
           </button>
-          <span class="tooltip__content" role="tooltip">
-            Tooltip no icon-button
-          </span>
-        </span>
-
-        <span class="tooltip tooltip--bottom">
-          <a class="tooltip__trigger link" href="#">Hover/Focus bottom</a>
-          <span class="tooltip__content" role="tooltip">
-            Tooltip bottom com texto longo para conferir animação de cima para
-            baixo e leitura completa.
-          </span>
-        </span>
-      </div>
-
-      <!-- Icon Button — exemplos -->
-      <div
-        style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;"
-      >
-        <button class="icon-button icon-button--lg" aria-label="Confirmar">
-          <i class="lui lui-check" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--lg" aria-label="Excluir">
-          <i class="lui lui-trash" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--lg" aria-label="Fechar">
-          <i class="lui lui-x" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--lg" aria-label="Informações">
-          <i class="lui lui-info-circle" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--lg" aria-label="Avançar">
-          <i class="lui lui-caret-right" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--lg" aria-label="Mais opções">
-          <i class="lui lui-dots-three" aria-hidden="true"></i>
-        </button>
-      </div>
-      <div
-        style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;"
-      >
-        <button
-          class="icon-button icon-button--lg"
-          aria-label="Confirmar (solid)"
-        >
-          <i class="lui-solid lui-check" aria-hidden="true"></i>
-        </button>
-        <button
-          class="icon-button icon-button--lg"
-          aria-label="Excluir (solid)"
-        >
-          <i class="lui-solid lui-trash" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--lg" aria-label="Fechar (solid)">
-          <i class="lui-solid lui-x" aria-hidden="true"></i>
-        </button>
-        <button
-          class="icon-button icon-button--md"
-          aria-label="Informações (md)"
-        >
-          <i class="lui lui-info-circle" aria-hidden="true"></i>
-        </button>
-        <button class="icon-button icon-button--md" aria-label="Fechar (md)">
-          <i class="lui lui-x" aria-hidden="true"></i>
-        </button>
-        <button
-          class="icon-button icon-button--md"
-          disabled
-          aria-disabled="true"
-          aria-label="Excluir (desabilitado)"
-        >
-          <i class="lui lui-trash" aria-hidden="true"></i>
-        </button>
-      </div>
-
-      <article class="card card__border" aria-label="Card exemplo">
-        <div class="card__cover">
-          <img src="https://picsum.photos/640/360" alt="Cover image" />
-        </div>
-        <div class="card__body">
-          <p class="body--lg text-bold">Card title</p>
-          <p class="body--lg">Card description</p>
-          <div class="card-actions" role="group" aria-label="Card actions">
-            <button class="btn btn--secondary btn--lg">Cancel</button>
-            <button class="btn btn--primary btn--lg">Action</button>
-          </div>
-        </div>
-      </article>
-
-      <!-- Divider standalone -->
-      <div class="divider" role="separator"></div>
-      <div class="divider divider--labeled" role="separator" aria-label="ou">
-        <span class="divider__label">ou</span>
-      </div>
-
-      <div
-        style="display: flex; align-items: stretch; height: 48px; gap: 16px;"
-      >
-        <span>Esquerda</span>
-        <div class="divider divider--vertical" role="separator"></div>
-        <span>Direita</span>
-        <div
-          class="divider divider--labeled divider--vertical"
-          role="separator"
-          aria-label="ou"
-        >
-          <span class="divider__label">ou</span>
-        </div>
-        <span>Mais</span>
-      </div>
-
-      <!-- Dropdown Menu -->
-      <div class="dropdown-menu" id="dropdown">
-        <button
-          class="btn btn--secondary btn--md"
-          type="button"
-          id="dropdown-trigger"
-          aria-haspopup="menu"
-          aria-expanded="false"
-          aria-controls="dropdown-panel"
-        >
-          Opções
-        </button>
-        <ul
-          id="dropdown-panel"
-          class="dropdown-menu__panel"
-          role="menu"
-          aria-labelledby="dropdown-trigger"
-        >
-          <li role="presentation">
-            <button class="menu-item" role="menuitem" type="button">
-              <span class="menu-item__label">Editar</span>
-              <span
-                class="menu-item__shortcut shortcut"
-                role="group"
-                aria-label="⌘ + E"
-              >
-                <kbd class="shortcut__key">⌘</kbd>
-                <span class="shortcut__sep" aria-hidden="true">+</span>
-                <kbd class="shortcut__key">E</kbd>
-              </span>
-            </button>
-          </li>
-          <li role="presentation">
-            <button class="menu-item" role="menuitem" type="button">
-              <span class="menu-item__label">Duplicar</span>
-              <span
-                class="menu-item__shortcut shortcut"
-                role="group"
-                aria-label="⌘ + D"
-              >
-                <kbd class="shortcut__key">⌘</kbd>
-                <span class="shortcut__sep" aria-hidden="true">+</span>
-                <kbd class="shortcut__key">D</kbd>
-              </span>
-            </button>
-          </li>
-          <li role="separator" class="divider"></li>
-          <li role="presentation" class="menu-item--has-submenu">
-            <button
-              class="menu-item"
-              role="menuitem"
-              type="button"
-              aria-haspopup="menu"
-              aria-expanded="false"
-            >
-              <span class="menu-item__label">Compartilhar</span>
-              <span class="menu-item__chevron" aria-hidden="true">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                >
-                  <path
-                    d="M6 4L10 8L6 12"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"></path>
-                </svg>
-              </span>
-            </button>
-            <ul class="dropdown-menu__panel" role="menu">
-              <li role="presentation">
-                <button class="menu-item" role="menuitem" type="button">
-                  <span class="menu-item__label">Por e-mail</span>
-                </button>
-              </li>
-              <li role="presentation">
-                <button class="menu-item" role="menuitem" type="button">
-                  <span class="menu-item__label">Copiar link</span>
-                  <span
-                    class="menu-item__shortcut shortcut"
-                    role="group"
-                    aria-label="⌘ + Shift + C"
-                  >
-                    <kbd class="shortcut__key">⌘</kbd>
-                    <span class="shortcut__sep" aria-hidden="true">+</span>
-                    <kbd class="shortcut__key">Shift</kbd>
-                    <span class="shortcut__sep" aria-hidden="true">+</span>
-                    <kbd class="shortcut__key">C</kbd>
-                  </span>
-                </button>
-              </li>
-            </ul>
-          </li>
-          <li role="separator" class="divider"></li>
-          <li role="presentation">
-            <button
-              class="menu-item menu-item--danger"
-              role="menuitem"
-              type="button"
-            >
-              <span class="menu-item__label">Excluir</span>
-            </button>
-          </li>
-          <li role="presentation">
-            <button
-              class="menu-item"
-              role="menuitem"
-              type="button"
-              disabled
-              aria-disabled="true"
-            >
-              <span class="menu-item__label">Desabilitado</span>
-            </button>
-          </li>
-        </ul>
-      </div>
-
-      <button id="openInternalModal" class="btn btn--primary btn--lg">
-        Abrir modal (interno)
-      </button>
-
-      <div
-        id="modalInternal"
-        class="modal modal--md is-hidden"
-        tabindex="-1"
-        role="dialog"
-      >
-        <div class="modal__header">Modal title</div>
-        <div class="modal__body">
-          <p>Modal com trigger interno</p>
-        </div>
-        <div class="modal__footer">
-          <button class="btn btn--secondary btn--lg" data-modal-close>
-            Cancelar
-          </button>
-          <button class="btn btn--primary btn--lg" data-modal-close>
-            Continuar
-          </button>
-        </div>
-      </div>
-
-      <div>
-        <button id="openExternalModal">Abrir modal externo</button>
-        <button id="closeAllModals">Fechar modais</button>
-      </div>
-
-      <div
-        id="modalExternal"
-        class="modal modal--sm is-hidden"
-        tabindex="-1"
-        role="dialog"
-      >
-        <div class="modal__header">Modal externo</div>
-        <div class="modal__body">
-          <p>Este modal abre via botão externo</p>
-        </div>
-        <div class="modal__footer">
-          <button class="btn btn--secondary btn--lg" data-modal-close>
-            Fechar
-          </button>
-          <button class="btn btn--primary btn--lg" data-modal-close>Ok</button>
-        </div>
-      </div>
-
-      <!-- Drawer -->
-      <button
-        id="drawer-trigger"
-        type="button"
-        class="btn btn--primary btn--lg"
-        aria-haspopup="dialog"
-        aria-controls="drawer-panel"
-        aria-expanded="false"
-      >
-        Abrir drawer
-      </button>
-
-      <div id="drawer-backdrop" class="drawer-backdrop" aria-hidden="true">
-      </div>
-
-      <div
-        id="drawer-panel"
-        class="drawer drawer--md"
-        tabindex="-1"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="drawer-title"
-        aria-hidden="true"
-        inert
-      >
-        <div class="drawer__header">
-          <span id="drawer-title" class="drawer__title">Configurações</span>
-          <button
-            id="drawer-close-btn"
-            type="button"
-            class="icon-button icon-button--md"
-            aria-label="Fechar drawer"
-          >
+          <button class="icon-button icon-button--md" aria-label="Fechar (md)">
             <i class="lui lui-x" aria-hidden="true"></i>
           </button>
-        </div>
-        <div class="drawer__body">
-          <p>
-            Conteúdo do drawer. Pode ser qualquer elemento HTML ou componente.
-          </p>
-          <p style="margin-top: 12px;">
-            Use o drawer para exibir detalhes, configurações ou ações
-            secundárias sem sair do contexto da página principal.
-          </p>
-        </div>
-        <div class="drawer__footer">
           <button
-            id="drawer-cancel"
-            type="button"
-            class="btn btn--secondary btn--lg">Cancelar</button
-          >
-          <button type="button" class="btn btn--primary btn--lg">Salvar</button>
-        </div>
-      </div>
-
-      <!-- Tabs — Line -->
-      <div class="tabs tabs--line">
-        <div class="tabs__list" role="tablist" aria-label="Seções">
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="true"
-            aria-controls="pg-line-panel-0"
-            id="pg-line-tab-0"
-            tabindex="0">Visão geral</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-line-panel-1"
-            id="pg-line-tab-1"
-            tabindex="-1">Configurações</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-line-panel-2"
-            id="pg-line-tab-2"
-            tabindex="-1"
+            class="icon-button icon-button--md"
             disabled
-            aria-disabled="true">Histórico</button
+            aria-disabled="true"
+            aria-label="Excluir (desabilitado)"
           >
+            <i class="lui lui-trash" aria-hidden="true"></i>
+          </button>
         </div>
+
+        <article class="card card__border" aria-label="Card exemplo">
+          <div class="card__cover">
+            <img src="https://picsum.photos/640/360" alt="Cover image" />
+          </div>
+          <div class="card__body">
+            <p class="body--lg text-bold">Card title</p>
+            <p class="body--lg">Card description</p>
+            <div class="card-actions" role="group" aria-label="Card actions">
+              <button class="btn btn--secondary btn--lg">Cancel</button>
+              <button class="btn btn--primary btn--lg">Action</button>
+            </div>
+          </div>
+        </article>
+
+        <!-- Divider standalone -->
+        <div class="divider" role="separator"></div>
+        <div class="divider divider--labeled" role="separator" aria-label="ou">
+          <span class="divider__label">ou</span>
+        </div>
+
         <div
-          id="pg-line-panel-0"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-line-tab-0"
+          style="display: flex; align-items: stretch; height: 48px; gap: 16px;"
         >
-          <p>Conteúdo da aba Visão geral.</p>
+          <span>Esquerda</span>
+          <div class="divider divider--vertical" role="separator"></div>
+          <span>Direita</span>
+          <div
+            class="divider divider--labeled divider--vertical"
+            role="separator"
+            aria-label="ou"
+          >
+            <span class="divider__label">ou</span>
+          </div>
+          <span>Mais</span>
         </div>
+
+        <!-- Dropdown Menu -->
+        <div class="dropdown-menu" id="dropdown">
+          <button
+            class="btn btn--secondary btn--md"
+            type="button"
+            id="dropdown-trigger"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls="dropdown-panel"
+          >
+            Opções
+          </button>
+          <ul
+            id="dropdown-panel"
+            class="dropdown-menu__panel"
+            role="menu"
+            aria-labelledby="dropdown-trigger"
+          >
+            <li role="presentation">
+              <button class="menu-item" role="menuitem" type="button">
+                <span class="menu-item__label">Editar</span>
+                <span
+                  class="menu-item__shortcut shortcut"
+                  role="group"
+                  aria-label="⌘ + E"
+                >
+                  <kbd class="shortcut__key">⌘</kbd>
+                  <span class="shortcut__sep" aria-hidden="true">+</span>
+                  <kbd class="shortcut__key">E</kbd>
+                </span>
+              </button>
+            </li>
+            <li role="presentation">
+              <button class="menu-item" role="menuitem" type="button">
+                <span class="menu-item__label">Duplicar</span>
+                <span
+                  class="menu-item__shortcut shortcut"
+                  role="group"
+                  aria-label="⌘ + D"
+                >
+                  <kbd class="shortcut__key">⌘</kbd>
+                  <span class="shortcut__sep" aria-hidden="true">+</span>
+                  <kbd class="shortcut__key">D</kbd>
+                </span>
+              </button>
+            </li>
+            <li role="separator" class="divider"></li>
+            <li role="presentation" class="menu-item--has-submenu">
+              <button
+                class="menu-item"
+                role="menuitem"
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded="false"
+              >
+                <span class="menu-item__label">Compartilhar</span>
+                <span class="menu-item__chevron" aria-hidden="true">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                  >
+                    <path
+                      d="M6 4L10 8L6 12"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"></path>
+                  </svg>
+                </span>
+              </button>
+              <ul class="dropdown-menu__panel" role="menu">
+                <li role="presentation">
+                  <button class="menu-item" role="menuitem" type="button">
+                    <span class="menu-item__label">Por e-mail</span>
+                  </button>
+                </li>
+                <li role="presentation">
+                  <button class="menu-item" role="menuitem" type="button">
+                    <span class="menu-item__label">Copiar link</span>
+                    <span
+                      class="menu-item__shortcut shortcut"
+                      role="group"
+                      aria-label="⌘ + Shift + C"
+                    >
+                      <kbd class="shortcut__key">⌘</kbd>
+                      <span class="shortcut__sep" aria-hidden="true">+</span>
+                      <kbd class="shortcut__key">Shift</kbd>
+                      <span class="shortcut__sep" aria-hidden="true">+</span>
+                      <kbd class="shortcut__key">C</kbd>
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </li>
+            <li role="separator" class="divider"></li>
+            <li role="presentation">
+              <button
+                class="menu-item menu-item--danger"
+                role="menuitem"
+                type="button"
+              >
+                <span class="menu-item__label">Excluir</span>
+              </button>
+            </li>
+            <li role="presentation">
+              <button
+                class="menu-item"
+                role="menuitem"
+                type="button"
+                disabled
+                aria-disabled="true"
+              >
+                <span class="menu-item__label">Desabilitado</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+
+        <button id="openInternalModal" class="btn btn--primary btn--lg">
+          Abrir modal (interno)
+        </button>
+
         <div
-          id="pg-line-panel-1"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-line-tab-1"
-          hidden
+          id="modalInternal"
+          class="modal modal--md is-hidden"
+          tabindex="-1"
+          role="dialog"
         >
-          <p>Conteúdo da aba Configurações.</p>
+          <div class="modal__header">Modal title</div>
+          <div class="modal__body">
+            <p>Modal com trigger interno</p>
+          </div>
+          <div class="modal__footer">
+            <button class="btn btn--secondary btn--lg" data-modal-close>
+              Cancelar
+            </button>
+            <button class="btn btn--primary btn--lg" data-modal-close>
+              Continuar
+            </button>
+          </div>
         </div>
+
+        <div>
+          <button id="openExternalModal">Abrir modal externo</button>
+          <button id="closeAllModals">Fechar modais</button>
+        </div>
+
         <div
-          id="pg-line-panel-2"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-line-tab-2"
-          hidden
+          id="modalExternal"
+          class="modal modal--sm is-hidden"
+          tabindex="-1"
+          role="dialog"
         >
-          <p>Conteúdo da aba Histórico.</p>
+          <div class="modal__header">Modal externo</div>
+          <div class="modal__body">
+            <p>Este modal abre via botão externo</p>
+          </div>
+          <div class="modal__footer">
+            <button class="btn btn--secondary btn--lg" data-modal-close>
+              Fechar
+            </button>
+            <button class="btn btn--primary btn--lg" data-modal-close>Ok</button
+            >
+          </div>
         </div>
+
+        <!-- Drawer -->
+        <button
+          id="drawer-trigger"
+          type="button"
+          class="btn btn--primary btn--lg"
+          aria-haspopup="dialog"
+          aria-controls="drawer-panel"
+          aria-expanded="false"
+        >
+          Abrir drawer
+        </button>
+
+        <div id="drawer-backdrop" class="drawer-backdrop" aria-hidden="true">
+        </div>
+
+        <div
+          id="drawer-panel"
+          class="drawer drawer--md"
+          tabindex="-1"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="drawer-title"
+          aria-hidden="true"
+          inert
+        >
+          <div class="drawer__header">
+            <span id="drawer-title" class="drawer__title">Configurações</span>
+            <button
+              id="drawer-close-btn"
+              type="button"
+              class="icon-button icon-button--md"
+              aria-label="Fechar drawer"
+            >
+              <i class="lui lui-x" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div class="drawer__body">
+            <p>
+              Conteúdo do drawer. Pode ser qualquer elemento HTML ou componente.
+            </p>
+            <p style="margin-top: 12px;">
+              Use o drawer para exibir detalhes, configurações ou ações
+              secundárias sem sair do contexto da página principal.
+            </p>
+          </div>
+          <div class="drawer__footer">
+            <button
+              id="drawer-cancel"
+              type="button"
+              class="btn btn--secondary btn--lg">Cancelar</button
+            >
+            <button type="button" class="btn btn--primary btn--lg"
+              >Salvar</button
+            >
+          </div>
+        </div>
+
+        <!-- Tabs — Line -->
+        <div class="tabs tabs--line">
+          <div class="tabs__list" role="tablist" aria-label="Seções">
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="true"
+              aria-controls="pg-line-panel-0"
+              id="pg-line-tab-0"
+              tabindex="0">Visão geral</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-line-panel-1"
+              id="pg-line-tab-1"
+              tabindex="-1">Configurações</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-line-panel-2"
+              id="pg-line-tab-2"
+              tabindex="-1"
+              disabled
+              aria-disabled="true">Histórico</button
+            >
+          </div>
+          <div
+            id="pg-line-panel-0"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-line-tab-0"
+          >
+            <p>Conteúdo da aba Visão geral.</p>
+          </div>
+          <div
+            id="pg-line-panel-1"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-line-tab-1"
+            hidden
+          >
+            <p>Conteúdo da aba Configurações.</p>
+          </div>
+          <div
+            id="pg-line-panel-2"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-line-tab-2"
+            hidden
+          >
+            <p>Conteúdo da aba Histórico.</p>
+          </div>
+        </div>
+
+        <!-- Tabs — Card -->
+        <div class="tabs tabs--card">
+          <div class="tabs__list" role="tablist" aria-label="Período">
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="true"
+              aria-controls="pg-card-panel-0"
+              id="pg-card-tab-0"
+              tabindex="0">Dia</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-card-panel-1"
+              id="pg-card-tab-1"
+              tabindex="-1">Semana</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-card-panel-2"
+              id="pg-card-tab-2"
+              tabindex="-1">Mês</button
+            >
+          </div>
+          <div
+            id="pg-card-panel-0"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-card-tab-0"
+          >
+            <p>Conteúdo da aba Dia.</p>
+          </div>
+          <div
+            id="pg-card-panel-1"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-card-tab-1"
+            hidden
+          >
+            <p>Conteúdo da aba Semana.</p>
+          </div>
+          <div
+            id="pg-card-panel-2"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-card-tab-2"
+            hidden
+          >
+            <p>Conteúdo da aba Mês.</p>
+          </div>
+        </div>
+
+        <!-- Tabs — Line expand -->
+        <div class="tabs tabs--line">
+          <div
+            class="tabs__list tabs__list--expand"
+            role="tablist"
+            aria-label="Seções expandidas"
+          >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="true"
+              aria-controls="pg-line-exp-panel-0"
+              id="pg-line-exp-tab-0"
+              tabindex="0">Visão geral</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-line-exp-panel-1"
+              id="pg-line-exp-tab-1"
+              tabindex="-1">Configurações</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-line-exp-panel-2"
+              id="pg-line-exp-tab-2"
+              tabindex="-1">Histórico</button
+            >
+          </div>
+          <div
+            id="pg-line-exp-panel-0"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-line-exp-tab-0"
+          >
+            <p>Conteúdo da aba Visão geral.</p>
+          </div>
+          <div
+            id="pg-line-exp-panel-1"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-line-exp-tab-1"
+            hidden
+          >
+            <p>Conteúdo da aba Configurações.</p>
+          </div>
+          <div
+            id="pg-line-exp-panel-2"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-line-exp-tab-2"
+            hidden
+          >
+            <p>Conteúdo da aba Histórico.</p>
+          </div>
+        </div>
+
+        <!-- Tabs — Card expand -->
+        <div class="tabs tabs--card">
+          <div
+            class="tabs__list tabs__list--expand"
+            role="tablist"
+            aria-label="Período expandido"
+          >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="true"
+              aria-controls="pg-card-exp-panel-0"
+              id="pg-card-exp-tab-0"
+              tabindex="0">Dia</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-card-exp-panel-1"
+              id="pg-card-exp-tab-1"
+              tabindex="-1">Semana</button
+            >
+            <button
+              class="tab"
+              role="tab"
+              type="button"
+              aria-selected="false"
+              aria-controls="pg-card-exp-panel-2"
+              id="pg-card-exp-tab-2"
+              tabindex="-1">Mês</button
+            >
+          </div>
+          <div
+            id="pg-card-exp-panel-0"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-card-exp-tab-0"
+          >
+            <p>Conteúdo da aba Dia.</p>
+          </div>
+          <div
+            id="pg-card-exp-panel-1"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-card-exp-tab-1"
+            hidden
+          >
+            <p>Conteúdo da aba Semana.</p>
+          </div>
+          <div
+            id="pg-card-exp-panel-2"
+            class="tabs__panel"
+            role="tabpanel"
+            aria-labelledby="pg-card-exp-tab-2"
+            hidden
+          >
+            <p>Conteúdo da aba Mês.</p>
+          </div>
+        </div>
+
+        <div id="events">[event log]</div>
       </div>
 
-      <!-- Tabs — Card -->
-      <div class="tabs tabs--card">
-        <div class="tabs__list" role="tablist" aria-label="Período">
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="true"
-            aria-controls="pg-card-panel-0"
-            id="pg-card-tab-0"
-            tabindex="0">Dia</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-card-panel-1"
-            id="pg-card-tab-1"
-            tabindex="-1">Semana</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-card-panel-2"
-            id="pg-card-tab-2"
-            tabindex="-1">Mês</button
-          >
-        </div>
-        <div
-          id="pg-card-panel-0"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-card-tab-0"
-        >
-          <p>Conteúdo da aba Dia.</p>
-        </div>
-        <div
-          id="pg-card-panel-1"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-card-tab-1"
-          hidden
-        >
-          <p>Conteúdo da aba Semana.</p>
-        </div>
-        <div
-          id="pg-card-panel-2"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-card-tab-2"
-          hidden
-        >
-          <p>Conteúdo da aba Mês.</p>
-        </div>
-      </div>
+      <script type="module">
+        import { initUI } from '/scripts/ui.js';
 
-      <!-- Tabs — Line expand -->
-      <div class="tabs tabs--line">
-        <div
-          class="tabs__list tabs__list--expand"
-          role="tablist"
-          aria-label="Seções expandidas"
-        >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="true"
-            aria-controls="pg-line-exp-panel-0"
-            id="pg-line-exp-tab-0"
-            tabindex="0">Visão geral</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-line-exp-panel-1"
-            id="pg-line-exp-tab-1"
-            tabindex="-1">Configurações</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-line-exp-panel-2"
-            id="pg-line-exp-tab-2"
-            tabindex="-1">Histórico</button
-          >
-        </div>
-        <div
-          id="pg-line-exp-panel-0"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-line-exp-tab-0"
-        >
-          <p>Conteúdo da aba Visão geral.</p>
-        </div>
-        <div
-          id="pg-line-exp-panel-1"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-line-exp-tab-1"
-          hidden
-        >
-          <p>Conteúdo da aba Configurações.</p>
-        </div>
-        <div
-          id="pg-line-exp-panel-2"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-line-exp-tab-2"
-          hidden
-        >
-          <p>Conteúdo da aba Histórico.</p>
-        </div>
-      </div>
-
-      <!-- Tabs — Card expand -->
-      <div class="tabs tabs--card">
-        <div
-          class="tabs__list tabs__list--expand"
-          role="tablist"
-          aria-label="Período expandido"
-        >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="true"
-            aria-controls="pg-card-exp-panel-0"
-            id="pg-card-exp-tab-0"
-            tabindex="0">Dia</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-card-exp-panel-1"
-            id="pg-card-exp-tab-1"
-            tabindex="-1">Semana</button
-          >
-          <button
-            class="tab"
-            role="tab"
-            type="button"
-            aria-selected="false"
-            aria-controls="pg-card-exp-panel-2"
-            id="pg-card-exp-tab-2"
-            tabindex="-1">Mês</button
-          >
-        </div>
-        <div
-          id="pg-card-exp-panel-0"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-card-exp-tab-0"
-        >
-          <p>Conteúdo da aba Dia.</p>
-        </div>
-        <div
-          id="pg-card-exp-panel-1"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-card-exp-tab-1"
-          hidden
-        >
-          <p>Conteúdo da aba Semana.</p>
-        </div>
-        <div
-          id="pg-card-exp-panel-2"
-          class="tabs__panel"
-          role="tabpanel"
-          aria-labelledby="pg-card-exp-tab-2"
-          hidden
-        >
-          <p>Conteúdo da aba Mês.</p>
-        </div>
-      </div>
-
-      <div id="events">[event log]</div>
+        initUI();
+      </script>
     </section>
-
-    <script type="module">
-      import { initUI } from '/scripts/ui.js';
-
-      initUI();
-    </script>
   </body>
 </html>

--- a/packages/playground/src/pages/vanillacomponents.astro
+++ b/packages/playground/src/pages/vanillacomponents.astro
@@ -63,6 +63,40 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
         >
           Subtitle uppercase + color error
         </h2>
+      </div>
+
+      <!-- Typography — Body -->
+      <div style="display: flex; flex-direction: column; gap: 12px;">
+        <p class="body--lg lui-body--color-body">
+          Large — Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+        <p class="body--md lui-body--color-body">
+          Medium — Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+        <p class="body--sm lui-body--color-body">
+          Small — Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+        <p class="body--md lui-body--color-caption">Color caption</p>
+        <p class="body--md lui-body--color-body lui-body--italic">Itálico</p>
+        <p class="body--md lui-body--color-body lui-body--underline">
+          Sublinhado
+        </p>
+        <p
+          class="body--md lui-body--color-body lui-body--italic lui-body--underline"
+        >
+          Itálico + sublinhado
+        </p>
+        <p
+          class="body--md lui-body--color-body"
+          style="overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; max-width: 400px;"
+        >
+          Subtitle centralizado + color caption
+        </p>
+        <h2
+          class="subtitle lui-heading--color-error typography--transform-uppercase"
+        >
+          Subtitle uppercase + color error
+        </h2>
 
         <!-- Typography — Body -->
         <div style="display: flex; flex-direction: column; gap: 12px;">

--- a/packages/styles/src/components/_body.scss
+++ b/packages/styles/src/components/_body.scss
@@ -1,0 +1,5 @@
+@use '../utilities/functions' as *;
+
+lui-body {
+  display: contents;
+}

--- a/packages/styles/src/components/_components.scss
+++ b/packages/styles/src/components/_components.scss
@@ -1,6 +1,7 @@
 @use 'host';
 @use 'alert';
 @use 'image';
+@use 'body';
 @use 'breadcrumb';
 @use 'button';
 @use 'divider';
@@ -8,6 +9,7 @@
 @use 'dropdown-menu';
 @use 'card';
 @use 'checkbox';
+@use 'heading';
 @use 'icon-button';
 @use 'radio';
 @use 'switch';

--- a/packages/styles/src/components/_heading.scss
+++ b/packages/styles/src/components/_heading.scss
@@ -1,0 +1,5 @@
+@use '../utilities/functions' as *;
+
+lui-headline {
+  display: contents;
+}

--- a/packages/styles/src/components/_heading.scss
+++ b/packages/styles/src/components/_heading.scss
@@ -1,5 +1,5 @@
 @use '../utilities/functions' as *;
 
-lui-headline {
+lui-heading {
   display: contents;
 }


### PR DESCRIPTION
## Summary

- Adds `<lui-heading>` Web Component com 7 variantes (`display`, `title`, `subtitle`, `headline`, `subheadline`, `block-title`, `overtitle`) e tag HTML semântica padrão por variante
- Adds `<lui-body>` Web Component com variantes `lg`, `md`, `sm`, props de `italic` e `underline`
- Props compartilhadas `color`, `align`, `line-clamp` e `transform` usam classes `.text--*` definidas uma única vez em `_typography.scss`
- Storybook stories + MDX docs para ambos os componentes
- Playground atualizado com exemplos visuais

## Arquivos criados/modificados

| Arquivo | Tipo |
|---|---|
| `packages/styles/src/components/_heading.scss` | SCSS — cores e modificadores compartilhados |
| `packages/styles/src/components/_body.scss` | SCSS — cores e modificadores do body |
| `packages/lets-ui-components/src/components/heading.js` | Web Component |
| `packages/lets-ui-components/src/components/body.js` | Web Component |
| `docs/typography/Heading/` | Stories + MDX |
| `docs/typography/Body/` | Stories + MDX |

## Test plan

- [x] `pnpm build` sem erros ✅
- [x] `pnpm lint:css` sem erros ✅
- [x] Abrir Storybook e verificar `Components/Headline` e `Components/Body`
- [x] Testar prop `align`, `line-clamp`, `transform`, `color`, `italic`, `underline` nos controles do Storybook

Closes #29