### PR TITLE
feat(image): create lui-image web component

### DIFF
--- a/.changeset/brave-donuts-knock.md
+++ b/.changeset/brave-donuts-knock.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+Add Image component

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,17 +7,15 @@ const config = {
     '@chromatic-com/storybook',
     '@storybook/addon-vitest',
     '@storybook/addon-a11y',
-    {
-      name: '@storybook/addon-docs',
-      options: {
-        mdxPluginOptions: {
-          mdxCompileOptions: {
-            remarkPlugins: [remarkGfm],
-          },
-        },
-      },
-    },
+    '@storybook/addon-docs',
   ],
   framework: '@storybook/html-vite',
+  docs: {
+    mdxPluginOptions: {
+      mdxCompileOptions: {
+        remarkPlugins: [remarkGfm],
+      },
+    },
+  },
 };
 export default config;

--- a/docs/components/Image/Image.docs.mdx
+++ b/docs/components/Image/Image.docs.mdx
@@ -62,7 +62,7 @@ Use `as="picture"` to render a `<picture>` wrapper (for art-direction with `<sou
 | `alt`            | `string` (required)                              | —         | Alternative text; use `""` for decorative images           |
 | `width`          | `string`                                         | —         | CSS value applied to the wrapper (e.g. `400px`, `100%`)   |
 | `height`         | `string`                                         | —         | CSS value applied to the wrapper                           |
-| `aspect-ratio`   | `square` \| `video` \| `portrait` \| `landscape` \| `wide` | — | Locks layout space before load |
+| `aspect-ratio`   | `string` (any CSS value, e.g. `"16 / 9"`, `"1 / 1"`) | — | Applied as `aspect-ratio` CSS property on the wrapper |
 | `radius`         | `none` \| `xs` \| `sm` \| `md` \| `lg` \| `circle` | —      | Border radius using design tokens                          |
 | `fit`            | `cover` \| `contain` \| `none`                   | `cover`   | CSS `object-fit` value                                     |
 | `loading`        | `lazy` \| `eager`                                | `lazy`    | Native `loading` attribute                                 |

--- a/docs/components/Image/Image.docs.mdx
+++ b/docs/components/Image/Image.docs.mdx
@@ -1,0 +1,71 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as ImageStories from './Image.stories';
+
+<Meta of={ImageStories} />
+
+# Image
+
+The `<lui-image>` component wraps a native `<img>` (or `<picture>`) with lazy loading, a skeleton shimmer while loading, an error fallback, and optional aspect-ratio / object-fit controls — preventing layout shift and improving perceived performance.
+
+<Canvas of={ImageStories.Image} />
+<Controls of={ImageStories.Image} />
+
+## Aspect Ratios
+
+Use the `aspect-ratio` attribute to lock the space before the image loads and prevent CLS.
+
+<Canvas of={ImageStories.AspectRatios} />
+
+## Border Radii
+
+<Canvas of={ImageStories.BorderRadii} />
+
+## Object Fit
+
+<Canvas of={ImageStories.ObjectFit} />
+
+## Square / Circle
+
+<Canvas of={ImageStories.Square} />
+
+## With Caption
+
+When `caption` is provided, the component wraps everything in a semantic `<figure>` / `<figcaption>` pair.
+
+<Canvas of={ImageStories.WithCaption} />
+
+## Fallback Color
+
+Show a branded background while the image loads or when it fails.
+
+<Canvas of={ImageStories.FallbackColor} />
+
+## Fallback Source
+
+Provide an alternative image to display when the primary `src` fails to load.
+
+<Canvas of={ImageStories.FallbackSrc} />
+
+## As Picture
+
+Use `as="picture"` to render a `<picture>` wrapper (for art-direction with `<source>` elements).
+
+<Canvas of={ImageStories.AsPicture} />
+
+## Props
+
+| Attribute        | Type                                             | Default   | Description                                                |
+| ---------------- | ------------------------------------------------ | --------- | ---------------------------------------------------------- |
+| `as`             | `image` \| `picture`                             | `image`   | Renders `<img>` directly or wrapped in `<picture>`         |
+| `src`            | `string` (required)                              | —         | Image source URL                                           |
+| `src-set`        | `string`                                         | —         | Forwarded to the inner `<img srcset>`                      |
+| `alt`            | `string` (required)                              | —         | Alternative text; use `""` for decorative images           |
+| `width`          | `string`                                         | —         | CSS value applied to the wrapper (e.g. `400px`, `100%`)   |
+| `height`         | `string`                                         | —         | CSS value applied to the wrapper                           |
+| `aspect-ratio`   | `square` \| `video` \| `portrait` \| `landscape` \| `wide` | — | Locks layout space before load |
+| `radius`         | `none` \| `xs` \| `sm` \| `md` \| `lg` \| `circle` | —      | Border radius using design tokens                          |
+| `fit`            | `cover` \| `contain` \| `none`                   | `cover`   | CSS `object-fit` value                                     |
+| `loading`        | `lazy` \| `eager`                                | `lazy`    | Native `loading` attribute                                 |
+| `fallback-color` | `string`                                         | —         | Background color shown while loading / on error            |
+| `fallback-src`   | `string`                                         | —         | Alternative image URL shown when `src` fails               |
+| `caption`        | `string`                                         | —         | Wraps in `<figure>` and adds `<figcaption>`                |

--- a/docs/components/Image/Image.docs.mdx
+++ b/docs/components/Image/Image.docs.mdx
@@ -16,7 +16,7 @@ Use the `aspect-ratio` attribute to lock the space before the image loads and pr
 
 <Canvas of={ImageStories.AspectRatios} />
 
-## Border Radii
+## Border Radius
 
 <Canvas of={ImageStories.BorderRadii} />
 
@@ -51,21 +51,3 @@ Provide an alternative image to display when the primary `src` fails to load.
 Use `as="picture"` to render a `<picture>` wrapper (for art-direction with `<source>` elements).
 
 <Canvas of={ImageStories.AsPicture} />
-
-## Props
-
-| Attribute        | Type                                             | Default   | Description                                                |
-| ---------------- | ------------------------------------------------ | --------- | ---------------------------------------------------------- |
-| `as`             | `image` \| `picture`                             | `image`   | Renders `<img>` directly or wrapped in `<picture>`         |
-| `src`            | `string` (required)                              | —         | Image source URL                                           |
-| `src-set`        | `string`                                         | —         | Forwarded to the inner `<img srcset>`                      |
-| `alt`            | `string` (required)                              | —         | Alternative text; use `""` for decorative images           |
-| `width`          | `string`                                         | —         | CSS value applied to the wrapper (e.g. `400px`, `100%`)   |
-| `height`         | `string`                                         | —         | CSS value applied to the wrapper                           |
-| `aspect-ratio`   | `string` (any CSS value, e.g. `"16 / 9"`, `"1 / 1"`) | — | Applied as `aspect-ratio` CSS property on the wrapper |
-| `radius`         | `none` \| `xs` \| `sm` \| `md` \| `lg` \| `circle` | —      | Border radius using design tokens                          |
-| `fit`            | `cover` \| `contain` \| `none`                   | `cover`   | CSS `object-fit` value                                     |
-| `loading`        | `lazy` \| `eager`                                | `lazy`    | Native `loading` attribute                                 |
-| `fallback-color` | `string`                                         | —         | Background color shown while loading / on error            |
-| `fallback-src`   | `string`                                         | —         | Alternative image URL shown when `src` fails               |
-| `caption`        | `string`                                         | —         | Wraps in `<figure>` and adds `<figcaption>`                |

--- a/docs/components/Image/Image.stories.js
+++ b/docs/components/Image/Image.stories.js
@@ -14,10 +14,7 @@ export default {
     alt: { control: 'text' },
     width: { control: 'text' },
     height: { control: 'text' },
-    'aspect-ratio': {
-      control: { type: 'select' },
-      options: ['', 'square', 'video', 'portrait', 'landscape', 'wide'],
-    },
+    'aspect-ratio': { control: 'text' },
     radius: {
       control: { type: 'select' },
       options: ['none', 'xs', 'sm', 'md', 'lg', 'circle'],
@@ -49,7 +46,7 @@ Image.args = {
   src: SAMPLE_SRC,
   alt: 'Mountain landscape at sunset',
   width: '400px',
-  'aspect-ratio': 'video',
+  'aspect-ratio': '16 / 9',
   radius: 'md',
   fit: 'cover',
   loading: 'eager',
@@ -63,7 +60,7 @@ export const Square = () => `
     src="${PORTRAIT_SRC}"
     alt="Portrait photo"
     width="200px"
-    aspect-ratio="square"
+    aspect-ratio="1 / 1"
     radius="circle"
     fit="cover"
     loading="eager"
@@ -76,7 +73,7 @@ export const WithCaption = () => `
       src="${SAMPLE_SRC}"
       alt="Mountain landscape at sunset"
       width="400px"
-      aspect-ratio="video"
+      aspect-ratio="16 / 9"
       radius="md"
       fit="cover"
       loading="eager"
@@ -88,24 +85,24 @@ export const WithCaption = () => `
 export const AspectRatios = () => `
   <div style="display:flex;flex-direction:column;gap:24px;max-width:500px;">
     <div>
-      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Square (1/1)</p>
-      <lui-image src="${SAMPLE_SRC}" alt="Square" width="200px" aspect-ratio="square" fit="cover" loading="eager"></lui-image>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">1 / 1</p>
+      <lui-image src="${SAMPLE_SRC}" alt="Square" width="200px" aspect-ratio="1 / 1" fit="cover" loading="eager"></lui-image>
     </div>
     <div>
-      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Video (16/9)</p>
-      <lui-image src="${SAMPLE_SRC}" alt="Video" width="100%" aspect-ratio="video" fit="cover" loading="eager"></lui-image>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">16 / 9</p>
+      <lui-image src="${SAMPLE_SRC}" alt="16/9" width="100%" aspect-ratio="16 / 9" fit="cover" loading="eager"></lui-image>
     </div>
     <div>
-      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Landscape (4/3)</p>
-      <lui-image src="${SAMPLE_SRC}" alt="Landscape" width="100%" aspect-ratio="landscape" fit="cover" loading="eager"></lui-image>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">4 / 3</p>
+      <lui-image src="${SAMPLE_SRC}" alt="4/3" width="100%" aspect-ratio="4 / 3" fit="cover" loading="eager"></lui-image>
     </div>
     <div>
-      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Portrait (3/4)</p>
-      <lui-image src="${PORTRAIT_SRC}" alt="Portrait" width="200px" aspect-ratio="portrait" fit="cover" loading="eager"></lui-image>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">3 / 4</p>
+      <lui-image src="${PORTRAIT_SRC}" alt="3/4" width="200px" aspect-ratio="3 / 4" fit="cover" loading="eager"></lui-image>
     </div>
     <div>
-      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Wide (21/9)</p>
-      <lui-image src="${SAMPLE_SRC}" alt="Wide" width="100%" aspect-ratio="wide" fit="cover" loading="eager"></lui-image>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">21 / 9</p>
+      <lui-image src="${SAMPLE_SRC}" alt="21/9" width="100%" aspect-ratio="21 / 9" fit="cover" loading="eager"></lui-image>
     </div>
   </div>
 `;
@@ -117,7 +114,7 @@ export const BorderRadii = () => `
         (r) => `
       <div>
         <p style="font-size:12px;opacity:.6;margin-bottom:8px">${r}</p>
-        <lui-image src="${PORTRAIT_SRC}" alt="Radius ${r}" width="120px" aspect-ratio="square" radius="${r}" fit="cover" loading="eager"></lui-image>
+        <lui-image src="${PORTRAIT_SRC}" alt="Radius ${r}" width="120px" aspect-ratio="1 / 1" radius="${r}" fit="cover" loading="eager"></lui-image>
       </div>
     `
       )
@@ -145,7 +142,7 @@ export const FallbackColor = () => `
     src="https://invalid.example.com/broken.jpg"
     alt="Broken image with fallback color"
     width="300px"
-    aspect-ratio="video"
+    aspect-ratio="16 / 9"
     radius="md"
     fallback-color="#e8f4fd"
     loading="eager"
@@ -157,7 +154,7 @@ export const FallbackSrc = () => `
     src="https://invalid.example.com/broken.jpg"
     alt="Image with fallback source"
     width="300px"
-    aspect-ratio="video"
+    aspect-ratio="16 / 9"
     radius="md"
     fallback-src="${SAMPLE_SRC}"
     loading="eager"
@@ -170,7 +167,7 @@ export const AsPicture = () => `
     src="${SAMPLE_SRC}"
     alt="Mountain landscape"
     width="400px"
-    aspect-ratio="video"
+    aspect-ratio="16 / 9"
     radius="md"
     fit="cover"
     loading="eager"

--- a/docs/components/Image/Image.stories.js
+++ b/docs/components/Image/Image.stories.js
@@ -137,6 +137,34 @@ export const ObjectFit = () => `
   </div>
 `;
 
+export const ErrorState = () => `
+  <div style="display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;">
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">CSS fallback (padrão)</p>
+      <lui-image
+        src="https://invalid.example.com/broken.jpg"
+        alt="Broken image — CSS error state"
+        width="280px"
+        aspect-ratio="16 / 9"
+        radius="md"
+        loading="eager"
+      ></lui-image>
+    </div>
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">fallback-src manual</p>
+      <lui-image
+        src="https://invalid.example.com/broken.jpg"
+        alt="Broken image — custom fallback"
+        width="280px"
+        aspect-ratio="16 / 9"
+        radius="md"
+        fallback-src="${SAMPLE_SRC}"
+        loading="eager"
+      ></lui-image>
+    </div>
+  </div>
+`;
+
 export const FallbackColor = () => `
   <lui-image
     src="https://invalid.example.com/broken.jpg"
@@ -150,15 +178,20 @@ export const FallbackColor = () => `
 `;
 
 export const FallbackSrc = () => `
-  <lui-image
-    src="https://invalid.example.com/broken.jpg"
-    alt="Image with fallback source"
-    width="300px"
-    aspect-ratio="16 / 9"
-    radius="md"
-    fallback-src="${SAMPLE_SRC}"
-    loading="eager"
-  ></lui-image>
+  <div style="display:flex;flex-direction:column;gap:8px;">
+    <p style="font-size:12px;opacity:.6;margin:0">
+      Quando o src falha, carrega a imagem em fallback-src. Se o fallback também falhar, exibe o estado de erro CSS.
+    </p>
+    <lui-image
+      src="https://invalid.example.com/broken.jpg"
+      alt="Image with fallback source"
+      width="300px"
+      aspect-ratio="16 / 9"
+      radius="md"
+      fallback-src="${SAMPLE_SRC}"
+      loading="eager"
+    ></lui-image>
+  </div>
 `;
 
 export const AsPicture = () => `

--- a/docs/components/Image/Image.stories.js
+++ b/docs/components/Image/Image.stories.js
@@ -1,0 +1,178 @@
+import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
+import '../../../packages/styles/dist/letsui.css';
+import '../../../packages/lets-ui-components/src/index.js';
+
+const SAMPLE_SRC =
+  'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80';
+const PORTRAIT_SRC =
+  'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80';
+
+export default {
+  title: 'Components/Image',
+  argTypes: {
+    src: { control: 'text' },
+    alt: { control: 'text' },
+    width: { control: 'text' },
+    height: { control: 'text' },
+    'aspect-ratio': {
+      control: { type: 'select' },
+      options: ['', 'square', 'video', 'portrait', 'landscape', 'wide'],
+    },
+    radius: {
+      control: { type: 'select' },
+      options: ['none', 'xs', 'sm', 'md', 'lg', 'circle'],
+    },
+    fit: {
+      control: { type: 'select' },
+      options: ['cover', 'contain', 'none'],
+    },
+    loading: {
+      control: { type: 'select' },
+      options: ['lazy', 'eager'],
+    },
+    caption: { control: 'text' },
+    'fallback-color': { control: 'color' },
+    'fallback-src': { control: 'text' },
+  },
+};
+
+const Template = (args) => {
+  const attrs = Object.entries(args)
+    .filter(([, v]) => v !== '' && v !== undefined && v !== null)
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(' ');
+  return `<lui-image ${attrs}></lui-image>`;
+};
+
+export const Image = Template.bind({});
+Image.args = {
+  src: SAMPLE_SRC,
+  alt: 'Mountain landscape at sunset',
+  width: '400px',
+  'aspect-ratio': 'video',
+  radius: 'md',
+  fit: 'cover',
+  loading: 'eager',
+  caption: '',
+  'fallback-color': '',
+  'fallback-src': '',
+};
+
+export const Square = () => `
+  <lui-image
+    src="${PORTRAIT_SRC}"
+    alt="Portrait photo"
+    width="200px"
+    aspect-ratio="square"
+    radius="circle"
+    fit="cover"
+    loading="eager"
+  ></lui-image>
+`;
+
+export const WithCaption = () => `
+  <div style="width: 400px;">
+    <lui-image
+      src="${SAMPLE_SRC}"
+      alt="Mountain landscape at sunset"
+      width="400px"
+      aspect-ratio="video"
+      radius="md"
+      fit="cover"
+      loading="eager"
+      caption="Sunset over the mountains — Unsplash"
+    ></lui-image>
+  </div>
+`;
+
+export const AspectRatios = () => `
+  <div style="display:flex;flex-direction:column;gap:24px;max-width:500px;">
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Square (1/1)</p>
+      <lui-image src="${SAMPLE_SRC}" alt="Square" width="200px" aspect-ratio="square" fit="cover" loading="eager"></lui-image>
+    </div>
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Video (16/9)</p>
+      <lui-image src="${SAMPLE_SRC}" alt="Video" width="100%" aspect-ratio="video" fit="cover" loading="eager"></lui-image>
+    </div>
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Landscape (4/3)</p>
+      <lui-image src="${SAMPLE_SRC}" alt="Landscape" width="100%" aspect-ratio="landscape" fit="cover" loading="eager"></lui-image>
+    </div>
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Portrait (3/4)</p>
+      <lui-image src="${PORTRAIT_SRC}" alt="Portrait" width="200px" aspect-ratio="portrait" fit="cover" loading="eager"></lui-image>
+    </div>
+    <div>
+      <p style="font-size:12px;opacity:.6;margin-bottom:8px">Wide (21/9)</p>
+      <lui-image src="${SAMPLE_SRC}" alt="Wide" width="100%" aspect-ratio="wide" fit="cover" loading="eager"></lui-image>
+    </div>
+  </div>
+`;
+
+export const BorderRadii = () => `
+  <div style="display:flex;flex-wrap:wrap;gap:16px;align-items:flex-end;">
+    ${['none', 'xs', 'sm', 'md', 'lg', 'circle']
+      .map(
+        (r) => `
+      <div>
+        <p style="font-size:12px;opacity:.6;margin-bottom:8px">${r}</p>
+        <lui-image src="${PORTRAIT_SRC}" alt="Radius ${r}" width="120px" aspect-ratio="square" radius="${r}" fit="cover" loading="eager"></lui-image>
+      </div>
+    `
+      )
+      .join('')}
+  </div>
+`;
+
+export const ObjectFit = () => `
+  <div style="display:flex;gap:24px;align-items:flex-start;">
+    ${['cover', 'contain', 'none']
+      .map(
+        (f) => `
+      <div>
+        <p style="font-size:12px;opacity:.6;margin-bottom:8px">${f}</p>
+        <lui-image src="${SAMPLE_SRC}" alt="Fit ${f}" width="200px" height="150px" fit="${f}" radius="sm" loading="eager"></lui-image>
+      </div>
+    `
+      )
+      .join('')}
+  </div>
+`;
+
+export const FallbackColor = () => `
+  <lui-image
+    src="https://invalid.example.com/broken.jpg"
+    alt="Broken image with fallback color"
+    width="300px"
+    aspect-ratio="video"
+    radius="md"
+    fallback-color="#e8f4fd"
+    loading="eager"
+  ></lui-image>
+`;
+
+export const FallbackSrc = () => `
+  <lui-image
+    src="https://invalid.example.com/broken.jpg"
+    alt="Image with fallback source"
+    width="300px"
+    aspect-ratio="video"
+    radius="md"
+    fallback-src="${SAMPLE_SRC}"
+    loading="eager"
+  ></lui-image>
+`;
+
+export const AsPicture = () => `
+  <lui-image
+    as="picture"
+    src="${SAMPLE_SRC}"
+    alt="Mountain landscape"
+    width="400px"
+    aspect-ratio="video"
+    radius="md"
+    fit="cover"
+    loading="eager"
+  ></lui-image>
+`;

--- a/packages/lets-ui-components/src/components/image.js
+++ b/packages/lets-ui-components/src/components/image.js
@@ -1,0 +1,111 @@
+import { hasBooleanAttribute, mountMarkup } from '../internal.js';
+
+const VALID_FITS = ['cover', 'contain', 'none'];
+const VALID_RATIOS = ['square', 'video', 'portrait', 'landscape', 'wide'];
+const VALID_RADII = ['none', 'xs', 'sm', 'md', 'lg', 'circle'];
+
+export class LuiImage extends HTMLElement {
+  static observedAttributes = [
+    'as',
+    'src',
+    'src-set',
+    'alt',
+    'width',
+    'height',
+    'aspect-ratio',
+    'radius',
+    'fit',
+    'loading',
+    'fallback-color',
+    'fallback-src',
+    'caption',
+  ];
+
+  connectedCallback() {
+    this.render();
+  }
+
+  attributeChangedCallback() {
+    this.render();
+  }
+
+  #buildClasses() {
+    const fit = this.getAttribute('fit') ?? 'cover';
+    const ratio = this.getAttribute('aspect-ratio');
+    const radius = this.getAttribute('radius');
+
+    const classes = ['img'];
+
+    if (VALID_FITS.includes(fit)) classes.push(`img--fit-${fit}`);
+    if (ratio && VALID_RATIOS.includes(ratio))
+      classes.push(`img--ratio-${ratio}`);
+    if (radius && VALID_RADII.includes(radius))
+      classes.push(`img--radius-${radius}`);
+    if (this.getAttribute('as') === 'picture') classes.push('img--picture');
+
+    return classes.join(' ');
+  }
+
+  #buildStyles() {
+    const width = this.getAttribute('width');
+    const height = this.getAttribute('height');
+    const fallbackColor = this.getAttribute('fallback-color');
+    const styles = [];
+
+    if (width) styles.push(`width:${width}`);
+    if (height) styles.push(`height:${height}`);
+    if (fallbackColor) styles.push(`background-color:${fallbackColor}`);
+
+    return styles.length ? ` style="${styles.join(';')}"` : '';
+  }
+
+  #buildImgTag(src, srcSet, alt, loading) {
+    const srcSetAttr = srcSet ? ` srcset="${srcSet}"` : '';
+    return `<img class="img__element" src="${src}" alt="${alt}"${srcSetAttr} loading="${loading}" onload="this.closest('lui-image').__handleLoad()" onerror="this.closest('lui-image').__handleError()">`;
+  }
+
+  render() {
+    const as = this.getAttribute('as') ?? 'image';
+    const src = this.getAttribute('src') ?? '';
+    const srcSet = this.getAttribute('src-set') ?? '';
+    const alt = this.getAttribute('alt') ?? '';
+    const loading = this.getAttribute('loading') ?? 'lazy';
+    const caption = this.getAttribute('caption');
+
+    const wrapperClass = this.#buildClasses();
+    const wrapperStyle = this.#buildStyles();
+
+    const imgTag = this.#buildImgTag(src, srcSet, alt, loading);
+
+    const inner = as === 'picture' ? `<picture>${imgTag}</picture>` : imgTag;
+
+    const imageEl = `<div class="${wrapperClass} img--loading"${wrapperStyle}>${inner}</div>`;
+
+    const markup = caption
+      ? `<figure class="img-figure">${imageEl}<figcaption>${caption}</figcaption></figure>`
+      : imageEl;
+
+    mountMarkup(this, markup);
+
+    this.__handleLoad = () => {
+      const wrapper = this.querySelector('.img');
+      wrapper?.classList.remove('img--loading', 'img--error');
+    };
+
+    this.__handleError = () => {
+      const wrapper = this.querySelector('.img');
+      const fallbackSrc = this.getAttribute('fallback-src');
+      const img = this.querySelector('img');
+
+      wrapper?.classList.remove('img--loading');
+
+      if (fallbackSrc && img && img.src !== fallbackSrc) {
+        img.src = fallbackSrc;
+        return;
+      }
+
+      wrapper?.classList.add('img--error');
+      if (img) img.style.display = 'none';
+    };
+  }
+}

--- a/packages/lets-ui-components/src/components/image.js
+++ b/packages/lets-ui-components/src/components/image.js
@@ -14,6 +14,7 @@ export class LuiImage extends HTMLElement {
     'aspect-ratio',
     'radius',
     'fit',
+    'fill',
     'loading',
     'fallback-color',
     'fallback-src',
@@ -36,8 +37,9 @@ export class LuiImage extends HTMLElement {
 
     if (VALID_FITS.includes(fit)) classes.push(`img--fit-${fit}`);
     if (radius && VALID_RADII.includes(radius))
-      classes.push(`img--radius-${radius}`);
+      classes.push(`radius-${radius}`);
     if (this.getAttribute('as') === 'picture') classes.push('img--picture');
+    if (hasBooleanAttribute(this, 'fill')) classes.push('img--fill');
 
     return classes.join(' ');
   }
@@ -45,12 +47,14 @@ export class LuiImage extends HTMLElement {
   #buildStyles() {
     const width = this.getAttribute('width');
     const height = this.getAttribute('height');
+    const fillValue = this.getAttribute('fill');
     const ratio = this.getAttribute('aspect-ratio');
     const fallbackColor = this.getAttribute('fallback-color');
     const styles = [];
 
     if (width) styles.push(`width:${width}`);
-    if (height) styles.push(`height:${height}`);
+    if (fillValue) styles.push(`height:${fillValue}`);
+    else if (height) styles.push(`height:${height}`);
     if (ratio) styles.push(`aspect-ratio:${ratio}`);
     if (fallbackColor) styles.push(`background-color:${fallbackColor}`);
 
@@ -79,8 +83,12 @@ export class LuiImage extends HTMLElement {
 
     const imageEl = `<div class="${wrapperClass} img--loading"${wrapperStyle}>${inner}</div>`;
 
+    const figureClass = hasBooleanAttribute(this, 'fill')
+      ? 'img-figure img-figure--fill'
+      : 'img-figure';
+
     const markup = caption
-      ? `<figure class="img-figure">${imageEl}<figcaption>${caption}</figcaption></figure>`
+      ? `<figure class="${figureClass}">${imageEl}<figcaption>${caption}</figcaption></figure>`
       : imageEl;
 
     mountMarkup(this, markup);

--- a/packages/lets-ui-components/src/components/image.js
+++ b/packages/lets-ui-components/src/components/image.js
@@ -1,7 +1,6 @@
 import { hasBooleanAttribute, mountMarkup } from '../internal.js';
 
 const VALID_FITS = ['cover', 'contain', 'none'];
-const VALID_RATIOS = ['square', 'video', 'portrait', 'landscape', 'wide'];
 const VALID_RADII = ['none', 'xs', 'sm', 'md', 'lg', 'circle'];
 
 export class LuiImage extends HTMLElement {
@@ -31,14 +30,11 @@ export class LuiImage extends HTMLElement {
 
   #buildClasses() {
     const fit = this.getAttribute('fit') ?? 'cover';
-    const ratio = this.getAttribute('aspect-ratio');
     const radius = this.getAttribute('radius');
 
     const classes = ['img'];
 
     if (VALID_FITS.includes(fit)) classes.push(`img--fit-${fit}`);
-    if (ratio && VALID_RATIOS.includes(ratio))
-      classes.push(`img--ratio-${ratio}`);
     if (radius && VALID_RADII.includes(radius))
       classes.push(`img--radius-${radius}`);
     if (this.getAttribute('as') === 'picture') classes.push('img--picture');
@@ -49,11 +45,13 @@ export class LuiImage extends HTMLElement {
   #buildStyles() {
     const width = this.getAttribute('width');
     const height = this.getAttribute('height');
+    const ratio = this.getAttribute('aspect-ratio');
     const fallbackColor = this.getAttribute('fallback-color');
     const styles = [];
 
     if (width) styles.push(`width:${width}`);
     if (height) styles.push(`height:${height}`);
+    if (ratio) styles.push(`aspect-ratio:${ratio}`);
     if (fallbackColor) styles.push(`background-color:${fallbackColor}`);
 
     return styles.length ? ` style="${styles.join(';')}"` : '';

--- a/packages/lets-ui-components/src/index.js
+++ b/packages/lets-ui-components/src/index.js
@@ -1,5 +1,6 @@
 import { LuiAlert } from './components/alert.js';
 import { LuiBody } from './components/body.js';
+import { LuiImage } from './components/image.js';
 import { LuiDrawer } from './components/drawer.js';
 import { LuiHeading } from './components/heading.js';
 import { LuiTabs, LuiTab } from './components/tabs.js';
@@ -35,6 +36,7 @@ function define(name, elementClass) {
 define('lui-alert', LuiAlert);
 define('lui-body', LuiBody);
 define('lui-heading', LuiHeading);
+define('lui-image', LuiImage);
 define('lui-drawer', LuiDrawer);
 define('lui-tabs', LuiTabs);
 define('lui-tab', LuiTab);
@@ -64,6 +66,7 @@ export {
   LuiAlert,
   LuiBody,
   LuiHeading,
+  LuiImage,
   LuiDrawer,
   LuiTabs,
   LuiTab,

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -251,33 +251,42 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
       <!-- ── Image ─────────────────────────────────────────── -->
       <section class="pg-section">
         <h2 class="pg-section__title">Image</h2>
-        <div class="pg-row" style="align-items:flex-start;flex-wrap:wrap;gap:24px;">
+        <div
+          class="pg-row"
+          style="align-items:flex-start;flex-wrap:wrap;gap:24px;"
+        >
           <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Video 16/9 · radius md</p>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+              Video 16/9 · radius md
+            </p>
             <lui-image
               src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
               alt="Mountain landscape at sunset"
               width="320px"
-              aspect-ratio="video"
+              aspect-ratio="16 / 9"
               radius="md"
               fit="cover"
-              loading="eager"
-            ></lui-image>
+              loading="eager"></lui-image>
           </div>
           <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Square · radius circle</p>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+              Square · radius circle
+            </p>
             <lui-image
               src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80"
               alt="Portrait photo"
               width="120px"
-              aspect-ratio="square"
+              aspect-ratio="1 / 1"
               radius="circle"
               fit="cover"
               loading="eager"
-            ></lui-image>
+            >
+            </lui-image>
           </div>
           <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Fit contain · radius sm</p>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+              Fit contain · radius sm
+            </p>
             <lui-image
               src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
               alt="Contain fit"
@@ -286,31 +295,38 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
               fit="contain"
               radius="sm"
               loading="eager"
-            ></lui-image>
+            >
+            </lui-image>
           </div>
           <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Broken src · error state</p>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+              Broken src · error state
+            </p>
             <lui-image
               src="https://invalid.example.com/broken.jpg"
               alt="Broken image"
               width="200px"
-              aspect-ratio="video"
+              aspect-ratio="16 / 9"
               radius="md"
               loading="eager"
-            ></lui-image>
+            >
+            </lui-image>
           </div>
           <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Com caption (figure)</p>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+              Com caption (figure)
+            </p>
             <lui-image
               src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
               alt="Mountain landscape"
               width="280px"
-              aspect-ratio="landscape"
+              aspect-ratio="4 / 3"
               radius="md"
               fit="cover"
               loading="eager"
               caption="Foto: Unsplash — montanhas ao pôr do sol"
-            ></lui-image>
+            >
+            </lui-image>
           </div>
         </div>
       </section>

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -251,83 +251,98 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
       <!-- ── Image ─────────────────────────────────────────── -->
       <section class="pg-section">
         <h2 class="pg-section__title">Image</h2>
-        <div
-          class="pg-row"
-          style="align-items:flex-start;flex-wrap:wrap;gap:24px;"
+        <lui-image
+          src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+          alt="Mountain landscape at sunset"
+          fill="80px"
         >
-          <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-              Video 16/9 · radius md
-            </p>
-            <lui-image
-              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-              alt="Mountain landscape at sunset"
-              width="320px"
-              aspect-ratio="16 / 9"
-              radius="md"
-              fit="cover"
-              loading="eager"></lui-image>
-          </div>
-          <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-              Square · radius circle
-            </p>
-            <lui-image
-              src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80"
-              alt="Portrait photo"
-              width="120px"
-              aspect-ratio="1 / 1"
-              radius="circle"
-              fit="cover"
-              loading="eager"
-            >
-            </lui-image>
-          </div>
-          <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-              Fit contain · radius sm
-            </p>
-            <lui-image
-              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-              alt="Contain fit"
-              width="200px"
-              height="150px"
-              fit="contain"
-              radius="sm"
-              loading="eager"
-            >
-            </lui-image>
-          </div>
-          <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-              Broken src · error state
-            </p>
-            <lui-image
-              src="https://invalid.example.com/broken.jpg"
-              alt="Broken image"
-              width="200px"
-              aspect-ratio="16 / 9"
-              radius="md"
-              loading="eager"
-            >
-            </lui-image>
-          </div>
-          <div>
-            <p style="font-size:12px;opacity:.5;margin-bottom:8px">
-              Com caption (figure)
-            </p>
-            <lui-image
-              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
-              alt="Mountain landscape"
-              width="280px"
-              aspect-ratio="4 / 3"
-              radius="md"
-              fit="cover"
-              loading="eager"
-              caption="Foto: Unsplash — montanhas ao pôr do sol"
-            >
-            </lui-image>
-          </div>
+        </lui-image>
+        <div>
+          <lui-image
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+            alt="Mountain landscape at sunset"
+            width="320px"
+            aspect-ratio="16 / 9"
+            radius="md"
+            fit="cover"
+            loading="eager"
+          >
+          </lui-image>
+        </div>
+        <div>
+          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+            Square · radius circle
+          </p>
+          <lui-image
+            src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80"
+            alt="Portrait photo"
+            width="120px"
+            aspect-ratio="1 / 1"
+            radius="circle"
+            fit="cover"
+            loading="eager"
+          >
+          </lui-image>
+        </div>
+        <div>
+          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+            Fit contain · radius sm
+          </p>
+          <lui-image
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+            alt="Contain fit"
+            width="200px"
+            height="150px"
+            fit="contain"
+            radius="sm"
+            loading="eager"
+          >
+          </lui-image>
+        </div>
+        <div>
+          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+            Broken src · error state (CSS fallback)
+          </p>
+          <lui-image
+            src="https://invalid.example.com/broken.jpg"
+            alt="Broken image"
+            width="200px"
+            aspect-ratio="16 / 9"
+            radius="md"
+            loading="eager"
+          >
+          </lui-image>
+        </div>
+        <div>
+          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+            Broken src · fallback-src manual
+          </p>
+          <lui-image
+            src="https://invalid.example.com/broken.jpg"
+            alt="Imagem com fallback manual"
+            width="200px"
+            aspect-ratio="16 / 9"
+            radius="md"
+            fallback-src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+            loading="eager"
+          >
+          </lui-image>
+        </div>
+        <div>
+          <p style="font-size:12px;opacity:.5;margin-bottom:8px">
+            Com caption (figure)
+          </p>
+          <lui-image
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+            alt="Mountain landscape"
+            width="280px"
+            aspect-ratio="4 / 3"
+            radius="md"
+            fit="cover"
+            loading="eager"
+            caption="Foto: Unsplash — montanhas ao pôr do sol"
+          >
+          </lui-image>
         </div>
       </section>
     </main>

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -247,6 +247,73 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
           </lui-drawer>
         </div>
       </section>
+
+      <!-- ── Image ─────────────────────────────────────────── -->
+      <section class="pg-section">
+        <h2 class="pg-section__title">Image</h2>
+        <div class="pg-row" style="align-items:flex-start;flex-wrap:wrap;gap:24px;">
+          <div>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Video 16/9 · radius md</p>
+            <lui-image
+              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+              alt="Mountain landscape at sunset"
+              width="320px"
+              aspect-ratio="video"
+              radius="md"
+              fit="cover"
+              loading="eager"
+            ></lui-image>
+          </div>
+          <div>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Square · radius circle</p>
+            <lui-image
+              src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80"
+              alt="Portrait photo"
+              width="120px"
+              aspect-ratio="square"
+              radius="circle"
+              fit="cover"
+              loading="eager"
+            ></lui-image>
+          </div>
+          <div>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Fit contain · radius sm</p>
+            <lui-image
+              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+              alt="Contain fit"
+              width="200px"
+              height="150px"
+              fit="contain"
+              radius="sm"
+              loading="eager"
+            ></lui-image>
+          </div>
+          <div>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Broken src · error state</p>
+            <lui-image
+              src="https://invalid.example.com/broken.jpg"
+              alt="Broken image"
+              width="200px"
+              aspect-ratio="video"
+              radius="md"
+              loading="eager"
+            ></lui-image>
+          </div>
+          <div>
+            <p style="font-size:12px;opacity:.5;margin-bottom:8px">Com caption (figure)</p>
+            <lui-image
+              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+              alt="Mountain landscape"
+              width="280px"
+              aspect-ratio="landscape"
+              radius="md"
+              fit="cover"
+              loading="eager"
+              caption="Foto: Unsplash — montanhas ao pôr do sol"
+            ></lui-image>
+          </div>
+        </div>
+      </section>
     </main>
 
     <script>

--- a/packages/styles/src/components/_components.scss
+++ b/packages/styles/src/components/_components.scss
@@ -1,5 +1,6 @@
 @use 'host';
 @use 'alert';
+@use 'image';
 @use 'breadcrumb';
 @use 'button';
 @use 'divider';

--- a/packages/styles/src/components/_image.scss
+++ b/packages/styles/src/components/_image.scss
@@ -1,0 +1,144 @@
+@use '../utilities/functions' as *;
+
+.img {
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  background-color: bg(surface, neutral);
+
+  &__element {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__caption {
+    display: block;
+    margin-top: fluid(8);
+    color: text(body);
+  }
+
+  // aspect ratio
+  &--ratio-square {
+    aspect-ratio: 1 / 1;
+  }
+
+  &--ratio-video {
+    aspect-ratio: 16 / 9;
+  }
+
+  &--ratio-portrait {
+    aspect-ratio: 3 / 4;
+  }
+
+  &--ratio-landscape {
+    aspect-ratio: 4 / 3;
+  }
+
+  &--ratio-wide {
+    aspect-ratio: 21 / 9;
+  }
+
+  // object-fit
+  &--fit-cover .img__element {
+    object-fit: cover;
+  }
+
+  &--fit-contain .img__element {
+    object-fit: contain;
+  }
+
+  &--fit-none .img__element {
+    object-fit: none;
+  }
+
+  // border radius
+  &--radius-none {
+    border-radius: radius(none);
+  }
+
+  &--radius-xs {
+    border-radius: radius(xs);
+  }
+
+  &--radius-sm {
+    border-radius: radius(sm);
+  }
+
+  &--radius-md {
+    border-radius: radius(md);
+  }
+
+  &--radius-lg {
+    border-radius: radius(lg);
+  }
+
+  &--radius-circle {
+    border-radius: radius(circle);
+  }
+
+  // loading shimmer
+  &--loading {
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(
+        90deg,
+        bg(surface, neutral) 25%,
+        bg(container, neutral) 50%,
+        bg(surface, neutral) 75%
+      );
+      background-size: 200% 100%;
+      animation: img-shimmer 1.4s ease-in-out infinite;
+    }
+  }
+
+  // error state
+  &--error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: bg(container, neutral);
+
+    &::before {
+      content: '';
+      width: fixed(40);
+      height: fixed(40);
+      background-color: icon(neutral);
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5'%3E%3Crect x='3' y='3' width='18' height='18' rx='2'/%3E%3Ccircle cx='8.5' cy='8.5' r='1.5'/%3E%3Cpath d='m21 15-5-5L5 21'/%3E%3C/svg%3E");
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
+    }
+  }
+
+  // picture wrapper (when as=picture)
+  &--picture {
+    picture {
+      display: contents;
+    }
+  }
+}
+
+// figure wrapper
+.img-figure {
+  display: inline-block;
+
+  figcaption {
+    display: block;
+    margin-top: fluid(8);
+    color: text(body);
+  }
+}
+
+@keyframes img-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/packages/styles/src/components/_image.scss
+++ b/packages/styles/src/components/_image.scss
@@ -1,4 +1,12 @@
 @use '../utilities/functions' as *;
+@use '../utilities/mixins' as *;
+
+$fit: (contain, cover, none);
+
+lui-image[fill]:not([fill='false']) {
+  display: block;
+  width: 100%;
+}
 
 .img {
   display: inline-block;
@@ -20,41 +28,10 @@
   }
 
   // object-fit
-  &--fit-cover .img__element {
-    object-fit: cover;
-  }
-
-  &--fit-contain .img__element {
-    object-fit: contain;
-  }
-
-  &--fit-none .img__element {
-    object-fit: none;
-  }
-
-  // border radius
-  &--radius-none {
-    border-radius: radius(none);
-  }
-
-  &--radius-xs {
-    border-radius: radius(xs);
-  }
-
-  &--radius-sm {
-    border-radius: radius(sm);
-  }
-
-  &--radius-md {
-    border-radius: radius(md);
-  }
-
-  &--radius-lg {
-    border-radius: radius(lg);
-  }
-
-  &--radius-circle {
-    border-radius: radius(circle);
+  @each $f in $fit {
+    &--fit-#{$f} .img__element {
+      object-fit: $f;
+    }
   }
 
   // loading shimmer
@@ -85,7 +62,7 @@
       content: '';
       width: fixed(40);
       height: fixed(40);
-      background-color: icon(neutral);
+      background-color: color(gray, 4);
       mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5'%3E%3Crect x='3' y='3' width='18' height='18' rx='2'/%3E%3Ccircle cx='8.5' cy='8.5' r='1.5'/%3E%3Cpath d='m21 15-5-5L5 21'/%3E%3C/svg%3E");
       mask-size: contain;
       mask-repeat: no-repeat;
@@ -99,16 +76,29 @@
       display: contents;
     }
   }
+
+  // fill container width
+  &--fill {
+    display: block;
+    width: 100%;
+  }
 }
 
 // figure wrapper
 .img-figure {
   display: inline-block;
 
+  &--fill {
+    display: block;
+    width: 100%;
+  }
+
   figcaption {
     display: block;
-    margin-top: fluid(8);
-    color: text(body);
+    margin-top: fluid(4);
+    color: text(caption);
+
+    @include font-scale(body--md);
   }
 }
 

--- a/packages/styles/src/components/_image.scss
+++ b/packages/styles/src/components/_image.scss
@@ -19,27 +19,6 @@
     color: text(body);
   }
 
-  // aspect ratio
-  &--ratio-square {
-    aspect-ratio: 1 / 1;
-  }
-
-  &--ratio-video {
-    aspect-ratio: 16 / 9;
-  }
-
-  &--ratio-portrait {
-    aspect-ratio: 3 / 4;
-  }
-
-  &--ratio-landscape {
-    aspect-ratio: 4 / 3;
-  }
-
-  &--ratio-wide {
-    aspect-ratio: 21 / 9;
-  }
-
   // object-fit
   &--fit-cover .img__element {
     object-fit: cover;


### PR DESCRIPTION
## Summary

- Add `<lui-image>` Web Component with aspect-ratio, object-fit, border-radius (via tokens), lazy loading, shimmer skeleton while loading, and error fallback (inline icon state + fallback-src)
- Add `_image.scss` using only token functions — no hardcoded values
- Register component in `index.js` and forward all attributes reactively
- Add Storybook stories (`Image`, `Square`, `AspectRatios`, `BorderRadii`, `ObjectFit`, `WithCaption`, `FallbackColor`, `FallbackSrc`, `AsPicture`) and MDX documentation
- Apply to playground with representative variants

Closes #26

## Test plan

- [x] Build passes (`pnpm build`) with no errors
- [x] Lint passes (`pnpm lint:css`) with no warnings
- [x] Storybook shows all stories and controls work
- [x] Shimmer appears while image loads, disappears on `load` event
- [x] Broken `src` triggers error state (broken-image icon)
- [x] `fallback-src` replaces broken image with the fallback URL
- [x] `fallback-color` sets background color on wrapper
- [x] `caption` renders `<figure>` / `<figcaption>` semantics
- [x] `radius` values map correctly to token classes
- [x] `aspect-ratio` locks space before load (no CLS)
- [x] `as="picture"` wraps inner `<img>` in `<picture>`
- [x] Playground section renders all variants correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)