### PR TITLE
fix(docs): fix Modal Storybook stories and docs page

### DIFF
--- a/docs/components/Modal/Modal.docs.mdx
+++ b/docs/components/Modal/Modal.docs.mdx
@@ -16,10 +16,18 @@ Modals focus the user's attention exclusively on one task or piece of informatio
 
 <Canvas of={ModalStories.Large} />
 
-### Medium
-
-<Canvas of={ModalStories.Medium} />
-
 ### Small
 
 <Canvas of={ModalStories.Small} />
+
+## Without Actions
+
+Omit the `actions` slot to render a modal with no footer.
+
+<Canvas of={ModalStories.WithoutActions} />
+
+## Custom Trigger
+
+Slot any element with `slot="trigger"` to replace the default trigger button.
+
+<Canvas of={ModalStories.CustomTrigger} />

--- a/docs/components/Modal/Modal.stories.js
+++ b/docs/components/Modal/Modal.stories.js
@@ -13,6 +13,11 @@ export default {
     },
     'trigger-label': { control: 'text' },
   },
+  parameters: {
+    docs: {
+      story: { height: '500px' },
+    },
+  },
 };
 
 const Template = ({ title, size, 'trigger-label': triggerLabel }) => {

--- a/docs/components/Modal/Modal.stories.js
+++ b/docs/components/Modal/Modal.stories.js
@@ -11,19 +11,11 @@ export default {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
     },
-    triggerLabel: { control: 'text' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'Modals are used to display content in a layer above the app.',
-      },
-    },
+    'trigger-label': { control: 'text' },
   },
 };
 
-const Template = ({ title, size, triggerLabel }) => {
+const Template = ({ title, size, 'trigger-label': triggerLabel }) => {
   const attrs = [
     `title="${title ?? 'Modal title'}"`,
     `size="${size ?? 'md'}"`,
@@ -33,8 +25,8 @@ const Template = ({ title, size, triggerLabel }) => {
   return `
     <lui-modal ${attrs}>
       <p>This is the modal body text. It defines the main content of the modal.</p>
-      <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancel</button>
-      <button slot="actions" class="btn btn--primary btn--lg">Confirm</button>
+      <lui-button slot="actions" variant="secondary" label="Cancel" data-modal-close></lui-button>
+      <lui-button slot="actions" label="Confirm"></lui-button>
     </lui-modal>
   `;
 };
@@ -43,21 +35,21 @@ export const Default = Template.bind({});
 Default.args = {
   title: 'Modal title',
   size: 'md',
-  triggerLabel: 'Open modal',
+  'trigger-label': 'Open modal',
 };
 
 export const Small = Template.bind({});
 Small.args = {
-  ...Default.args,
   title: 'Small Modal',
   size: 'sm',
+  'trigger-label': 'Open modal',
 };
 
 export const Large = Template.bind({});
 Large.args = {
-  ...Default.args,
   title: 'Large Modal',
   size: 'lg',
+  'trigger-label': 'Open modal',
 };
 
 export const WithoutActions = () => `
@@ -69,13 +61,10 @@ WithoutActions.storyName = 'Without actions';
 
 export const CustomTrigger = () => `
   <lui-modal title="Modal with custom trigger">
-    <button slot="trigger" class="btn btn--secondary btn--lg">
-      <i class="lui lui-settings" aria-hidden="true"></i>
-      Settings
-    </button>
+    <lui-button slot="trigger" variant="secondary" label="Settings" icon-left="settings"></lui-button>
     <p>This modal uses a fully custom trigger via <code>slot="trigger"</code>.</p>
-    <button slot="actions" data-modal-close class="btn btn--secondary btn--lg">Cancel</button>
-    <button slot="actions" class="btn btn--primary btn--lg">Confirm</button>
+    <lui-button slot="actions" variant="secondary" label="Cancel" data-modal-close></lui-button>
+    <lui-button slot="actions" label="Confirm"></lui-button>
   </lui-modal>
 `;
 CustomTrigger.storyName = 'Custom trigger (slot)';


### PR DESCRIPTION
## Summary

- Remove reference to `ModalStories.Medium` in MDX docs — this export never existed and caused the docs page to crash on load
- Replace all raw CSS button classes (`btn--primary`, `btn--secondary`) with `<lui-button>` web component in every story
- Update `CustomTrigger` story to use `<lui-button slot="trigger">` instead of a raw `<button class="btn...">`
- Fix `argTypes` key from `triggerLabel` (camelCase) to `trigger-label` (kebab-case) to match the actual attribute
- Add `WithoutActions` and `CustomTrigger` sections to the MDX docs

Closes #35

## Test plan

- [x] Open Storybook → **Components / Modal** — docs page loads without errors
- [x] Default story renders `<lui-modal>` with `<lui-button>` actions; Controls update `title`, `size`, and `trigger-label`
- [x] Small and Large stories render correctly at their respective sizes
- [x] Without Actions story shows a modal with no footer
- [x] Custom Trigger story opens the modal via the slotted `<lui-button>`
- [x] No `btn`, `btn--*` class names remain anywhere in the stories file

🤖 Generated with [Claude Code](https://claude.com/claude-code)