### PR TITLE
fix: remove merge conflict markers

### DIFF
--- a/packages/lets-ui-components/src/index.js
+++ b/packages/lets-ui-components/src/index.js
@@ -36,10 +36,7 @@ function define(name, elementClass) {
 define('lui-alert', LuiAlert);
 define('lui-body', LuiBody);
 define('lui-heading', LuiHeading);
-<<<<<<< HEAD
 define('lui-image', LuiImage);
-=======
->>>>>>> 190150c (refactor(typography): rename lui-headline to lui-heading)
 define('lui-drawer', LuiDrawer);
 define('lui-tabs', LuiTabs);
 define('lui-tab', LuiTab);


### PR DESCRIPTION
## Summary

Fixes unresolved Git merge conflict markers left in:

- packages/lets-ui-components/src/index.js

These markers caused the CI build to fail during the Astro/Vite build step.

## Changes

- Removed leftover merge conflict markers:
  - <<<<<<<
  - =======
  - >>>>>>>
- Kept the correct component registrations in index.js
- Validated the fix by running the build locally

## Result

The project now builds correctly again and the release workflow can continue normally.