### PR TITLE
feat(storybook): custom theme and docs reorganization

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,5 +1,5 @@
 import { addons } from 'storybook/manager-api';
-import { create } from '@storybook/theming/create';
+import { create } from 'storybook/theming/create';
 
 addons.setConfig({
   theme: create({

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,55 @@
+import { addons } from 'storybook/manager-api';
+import { create } from '@storybook/theming/create';
+
+addons.setConfig({
+  theme: create({
+    base: 'light',
+
+    // Brand
+    brandTitle: "Let's UI",
+    brandUrl: '/',
+    brandImage: '/docs/public/logo.svg',
+    brandTarget: '_self',
+
+    // Accent — brand.color.primary.{4,5}
+    colorPrimary: '#8733ff',
+    colorSecondary: '#6825db',
+
+    // Shell — neutral.background + neutral.border tokens
+    appBg: '#f9f9f9',
+    appContentBg: '#ffffff',
+    appHoverBg: '#edd6ff',
+    appPreviewBg: '#ffffff',
+    appBorderColor: '#c7cad4',
+    appBorderRadius: 8,
+
+    // Typography — brand.typography.font-family.body + neutral.text tokens
+    fontBase:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif',
+    fontCode:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace',
+    textColor: '#282b33',
+    textInverseColor: '#ffffff',
+    textMutedColor: '#6c7081',
+
+    // Toolbar — neutral tokens
+    barBg: '#ffffff',
+    barTextColor: '#545867',
+    barHoverColor: '#8733ff',
+    barSelectedColor: '#8733ff',
+
+    // Buttons — neutral.background + neutral.border
+    buttonBg: '#eeecf1',
+    buttonBorder: '#c7cad4',
+
+    // Toggles — neutral.border + brand.primary
+    booleanBg: '#c7cad4',
+    booleanSelectedBg: '#8733ff',
+
+    // Inputs — neutral tokens + radius.sm
+    inputBg: '#ffffff',
+    inputBorder: '#c7cad4',
+    inputTextColor: '#282b33',
+    inputBorderRadius: 4,
+  }),
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,15 +11,17 @@ const preview = {
     options: {
       storySort: {
         order: [
-          'Get started', [
-            'Welcome',
-            'Designers',
-            'Developers',
-            'Changelog'
-          ],
+          'Get started',
+          ['Welcome', 'Designers', 'Developers', 'Changelog'],
           'Foundations',
-          'Components'
-        ]
+          'Actionable',
+          'Navigation',
+          'Form and options',
+          'Content',
+          'Miscellaneous',
+          'Utilities',
+          ['Functions', 'Mixins', 'Flex'],
+        ],
       },
     },
 
@@ -47,9 +49,7 @@ const preview = {
       defaultValue: 'lets-ui',
       toolbar: {
         icon: 'circlehollow',
-        items: [
-          { value: 'lets-ui', title: "Let's UI" },
-        ],
+        items: [{ value: 'lets-ui', title: "Let's UI" }],
       },
     },
   },

--- a/docs/components/Alert/Alert.stories.js
+++ b/docs/components/Alert/Alert.stories.js
@@ -1,6 +1,6 @@
+import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
-import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {

--- a/docs/components/Alert/Alert.stories.js
+++ b/docs/components/Alert/Alert.stories.js
@@ -4,7 +4,7 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Alert',
+  title: 'Content/Alert',
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/docs/components/Body/Body.stories.js
+++ b/docs/components/Body/Body.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Typography/Body',
+  title: 'Content/Typography/Body',
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/docs/components/Breadcrumb/Breadcrumb.stories.js
+++ b/docs/components/Breadcrumb/Breadcrumb.stories.js
@@ -2,17 +2,16 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Breadcrumb',
+  title: 'Navigation/Breadcrumb',
   // tags: ['autodocs'],
   argTypes: {
-    label: { 
-      control: 'text'
-    }
+    label: {
+      control: 'text',
+    },
   },
 };
 
 const Template = ({ label }) => {
-
   return `
     <ul class="breadcrumb">
       <li><a class="link">Item 1</a></li>

--- a/docs/components/Button/Button.stories.js
+++ b/docs/components/Button/Button.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Button',
+  title: 'Actionable/Button',
   // tags: ['autodocs'],
   argTypes: {
     label: {

--- a/docs/components/Card/Card.stories.js
+++ b/docs/components/Card/Card.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Card',
+  title: 'Content/Card',
   argTypes: {
     title: { control: 'text' },
     content: { control: 'text' },

--- a/docs/components/Checkbox/Checkbox.stories.js
+++ b/docs/components/Checkbox/Checkbox.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Checkbox',
+  title: 'Form and options/Checkbox',
   argTypes: {
     label: { control: 'text' },
     checked: { control: 'boolean' },

--- a/docs/components/Divider/Divider.stories.js
+++ b/docs/components/Divider/Divider.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Divider',
+  title: 'Miscellaneous/Divider',
   argTypes: {
     orientation: {
       control: {

--- a/docs/components/Drawer/Drawer.stories.js
+++ b/docs/components/Drawer/Drawer.stories.js
@@ -4,7 +4,7 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Drawer',
+  title: 'Content/Drawer',
   argTypes: {
     title: { control: 'text' },
     size: {

--- a/docs/components/Drawer/Drawer.stories.js
+++ b/docs/components/Drawer/Drawer.stories.js
@@ -1,6 +1,6 @@
+import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
-import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {

--- a/docs/components/DropdownMenu/DropdownMenu.stories.js
+++ b/docs/components/DropdownMenu/DropdownMenu.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import 'lets-ui-icons/dist/lets-ui-icons.css';
 
 export default {
-  title: 'Components/Dropdown Menu',
+  title: 'Actionable/Dropdown Menu',
   parameters: {
     docs: {
       description: {

--- a/docs/components/DropdownMenu/DropdownMenu.stories.js
+++ b/docs/components/DropdownMenu/DropdownMenu.stories.js
@@ -1,6 +1,6 @@
+import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
-import 'lets-ui-icons/dist/lets-ui-icons.css';
 
 export default {
   title: 'Actionable/Dropdown Menu',

--- a/docs/components/Heading/Heading.stories.js
+++ b/docs/components/Heading/Heading.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Typography/Heading',
+  title: 'Content/Typography/Heading',
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/docs/components/IconButton/IconButton.stories.js
+++ b/docs/components/IconButton/IconButton.stories.js
@@ -1,6 +1,6 @@
+import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
-import 'lets-ui-icons/dist/lets-ui-icons.css';
 
 export default {
   title: 'Actionable/Icon Button',

--- a/docs/components/IconButton/IconButton.stories.js
+++ b/docs/components/IconButton/IconButton.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import 'lets-ui-icons/dist/lets-ui-icons.css';
 
 export default {
-  title: 'Components/Icon Button',
+  title: 'Actionable/Icon Button',
   argTypes: {
     icon: {
       control: { type: 'select' },

--- a/docs/components/Image/Image.stories.js
+++ b/docs/components/Image/Image.stories.js
@@ -8,7 +8,7 @@ const PORTRAIT_SRC =
   'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&q=80';
 
 export default {
-  title: 'Components/Image',
+  title: 'Content/Image',
   argTypes: {
     src: { control: 'text' },
     alt: { control: 'text' },

--- a/docs/components/Input/Input.stories.js
+++ b/docs/components/Input/Input.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Input',
+  title: 'Form and options/Input',
   argTypes: {
     type: {
       control: { type: 'select' },

--- a/docs/components/Link/Link.docs.mdx
+++ b/docs/components/Link/Link.docs.mdx
@@ -1,0 +1,62 @@
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as LinkStories from './Link.stories';
+
+<Meta of={LinkStories} />
+
+# Link
+
+Componente de link navegável. Aplica a cor semântica `text(link)`, remove o sublinhado padrão, e restaura o sublinhado no hover. No estado `:visited` usa `text(link-visited)`. Foco gerenciado via `@include focus-ring(primary)`.
+
+<Canvas of={LinkStories.Default} />
+<Controls of={LinkStories.Default} />
+
+---
+
+## Em parágrafo
+
+Links geralmente aparecem inline dentro de blocos de texto. Use a tag `<a class="link">` diretamente para embutir um link em conteúdo corrido.
+
+<Canvas of={LinkStories.InParagraph} />
+
+---
+
+## Com aria-label
+
+Quando o texto do link não descreve o destino com clareza (ex.: "saiba mais", "clique aqui"), forneça um `aria-label` descritivo para leitores de tela.
+
+<Canvas of={LinkStories.WithAriaLabel} />
+
+---
+
+## Classe CSS (sem Web Component)
+
+A estilização de link está disponível diretamente via classe CSS `.link` em qualquer tag `<a>`, sem necessidade de usar o web component `<lui-link>`.
+
+<Canvas of={LinkStories.CSSClass} />
+
+---
+
+## Uso
+
+### Web Component
+
+```html
+<lui-link label="Saiba mais" href="/sobre"></lui-link>
+
+<!-- Com aria-label personalizado -->
+<lui-link
+  label="Leia mais"
+  href="/acessibilidade"
+  aria-label="Leia mais sobre acessibilidade"
+></lui-link>
+```
+
+### Classe CSS
+
+```html
+<!-- Link inline em texto -->
+<p>
+  Acesse a
+  <a class="link" href="/termos">política de privacidade</a>.
+</p>
+```

--- a/docs/components/Link/Link.stories.js
+++ b/docs/components/Link/Link.stories.js
@@ -1,0 +1,48 @@
+import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
+import '../../../packages/styles/dist/letsui.css';
+import '../../../packages/lets-ui-components/src/index.js';
+
+export default {
+  title: 'Navigation/Link',
+  argTypes: {
+    label: { control: 'text' },
+    href: { control: 'text' },
+    ariaLabel: { control: 'text' },
+  },
+};
+
+const Template = ({ label, href, ariaLabel }) => `
+  <lui-link
+    label="${label}"
+    href="${href}"
+    ${ariaLabel ? `aria-label="${ariaLabel}"` : ''}
+  ></lui-link>
+`;
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Saiba mais',
+  href: '#',
+  ariaLabel: '',
+};
+Default.storyName = 'Default';
+
+export const InParagraph = () => `
+  <p class="body--lg">
+    Ao continuar você concorda com os
+    <a class="link" href="#">termos de uso</a>
+    e com a
+    <a class="link" href="#">política de privacidade</a>.
+  </p>
+`;
+InParagraph.storyName = 'Em parágrafo';
+
+export const WithAriaLabel = () => `
+  <lui-link label="Leia mais" href="#" aria-label="Leia mais sobre acessibilidade"></lui-link>
+`;
+WithAriaLabel.storyName = 'Com aria-label';
+
+export const CSSClass = () => `
+  <a class="link" href="#">Link com classe CSS</a>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/docs/components/Modal/Modal.stories.js
+++ b/docs/components/Modal/Modal.stories.js
@@ -4,7 +4,7 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Modal',
+  title: 'Content/Modal',
   argTypes: {
     title: { control: 'text' },
     size: {

--- a/docs/components/Modal/Modal.stories.js
+++ b/docs/components/Modal/Modal.stories.js
@@ -1,6 +1,6 @@
+import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
-import 'lets-ui-icons/dist/lets-ui-icons.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {

--- a/docs/components/Radio/Radio.stories.js
+++ b/docs/components/Radio/Radio.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Radio',
+  title: 'Form and options/Radio',
   argTypes: {
     label: { control: 'text' },
     checked: { control: 'boolean' },

--- a/docs/components/Select/Select.stories.js
+++ b/docs/components/Select/Select.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Native Select',
+  title: 'Form and options/Native Select',
   argTypes: {
     label: { control: 'text' },
     placeholder: { control: 'text' },

--- a/docs/components/Shortcut/Shortcut.docs.mdx
+++ b/docs/components/Shortcut/Shortcut.docs.mdx
@@ -1,0 +1,29 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as ShortcutStories from './Shortcut.stories';
+
+<Meta of={ShortcutStories} />
+
+# Shortcut
+
+Exibe combinações de teclas de teclado de forma semântica e acessível. Use para comunicar atalhos disponíveis em tooltips, menus de contexto, listas de comandos e interfaces de ajuda. Cada tecla é renderizada com `<kbd>` e separada visualmente por `+`.
+
+<Canvas of={ShortcutStories.Shortcut} />
+<Controls of={ShortcutStories.Shortcut} />
+
+## Tecla única
+
+Use quando o atalho corresponde a uma única tecla — como teclas de ação (`Enter`, `Esc`, `Tab`). Ideal para indicar confirmação ou cancelamento em formulários e modais.
+
+<Canvas of={ShortcutStories.SingleKey} />
+
+## Múltiplas teclas
+
+Use quando o atalho exige uma combinação de teclas simultâneas. Passe as teclas separadas por vírgula no atributo `keys` (ex.: `keys="Ctrl,K"`). A ordem deve seguir a convenção da plataforma: modificadores primeiro (`Ctrl`, `Shift`, `Cmd`, `Alt`), depois a tecla principal.
+
+<Canvas of={ShortcutStories.MultipleKeys} />
+
+## Em contexto
+
+Combine com listas de ações ou menus para documentar atalhos disponíveis na interface. O componente se alinha naturalmente em layouts `flex` com `justify-content: space-between`.
+
+<Canvas of={ShortcutStories.InContext} />

--- a/docs/components/Shortcut/Shortcut.stories.js
+++ b/docs/components/Shortcut/Shortcut.stories.js
@@ -1,0 +1,60 @@
+import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
+import '../../../packages/styles/dist/letsui.css';
+import '../../../packages/lets-ui-components/src/index.js';
+
+export default {
+  title: 'Miscellaneous/Shortcut',
+  argTypes: {
+    keys: {
+      control: 'text',
+      description: 'Teclas separadas por vírgula (ex.: "Ctrl,K")',
+    },
+  },
+};
+
+const Template = ({ keys }) => `
+  <div style="padding: 24px;">
+    <lui-shortcut keys="${keys}"></lui-shortcut>
+  </div>
+`;
+
+export const Shortcut = Template.bind({});
+Shortcut.args = {
+  keys: 'Ctrl,K',
+};
+
+export const SingleKey = () => `
+  <div style="padding: 24px; display: flex; gap: 16px; align-items: center;">
+    <lui-shortcut keys="Esc"></lui-shortcut>
+    <lui-shortcut keys="Enter"></lui-shortcut>
+    <lui-shortcut keys="Tab"></lui-shortcut>
+  </div>
+`;
+
+export const MultipleKeys = () => `
+  <div style="padding: 24px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <lui-shortcut keys="Ctrl,K"></lui-shortcut>
+    <lui-shortcut keys="Ctrl,Shift,P"></lui-shortcut>
+    <lui-shortcut keys="Cmd,Z"></lui-shortcut>
+    <lui-shortcut keys="Cmd,Shift,Z"></lui-shortcut>
+  </div>
+`;
+
+export const InContext = () => `
+  <div style="padding: 24px; max-width: 320px;">
+    <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px;">
+      <li style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-radius: 6px; background: #f5f5f5;">
+        <span style="font-size: 14px;">Abrir busca</span>
+        <lui-shortcut keys="Ctrl,K"></lui-shortcut>
+      </li>
+      <li style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-radius: 6px; background: #f5f5f5;">
+        <span style="font-size: 14px;">Desfazer</span>
+        <lui-shortcut keys="Ctrl,Z"></lui-shortcut>
+      </li>
+      <li style="display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-radius: 6px; background: #f5f5f5;">
+        <span style="font-size: 14px;">Paleta de comandos</span>
+        <lui-shortcut keys="Ctrl,Shift,P"></lui-shortcut>
+      </li>
+    </ul>
+  </div>
+`;

--- a/docs/components/Switch/Switch.stories.js
+++ b/docs/components/Switch/Switch.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Switch',
+  title: 'Form and options/Switch',
   argTypes: {
     label: { control: 'text' },
     checked: { control: 'boolean' },

--- a/docs/components/Tabs/Tabs.stories.js
+++ b/docs/components/Tabs/Tabs.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Tabs',
+  title: 'Navigation/Tabs',
   parameters: {
     docs: {
       description: {

--- a/docs/components/Tag/Tag.stories.js
+++ b/docs/components/Tag/Tag.stories.js
@@ -2,7 +2,7 @@ import '../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
 import '../../../packages/styles/dist/letsui.css';
 
 export default {
-  title: 'Components/Tag',
+  title: 'Content/Tag',
   tags: ['autodocs'],
   argTypes: {
     label: {

--- a/docs/components/Textarea/Textarea.stories.js
+++ b/docs/components/Textarea/Textarea.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Textarea',
+  title: 'Form and options/Textarea',
   argTypes: {
     label: { control: 'text' },
     placeholder: { control: 'text' },

--- a/docs/components/Tooltip/Tooltip.stories.js
+++ b/docs/components/Tooltip/Tooltip.stories.js
@@ -3,7 +3,7 @@ import '../../../packages/styles/dist/letsui.css';
 import '../../../packages/lets-ui-components/src/index.js';
 
 export default {
-  title: 'Components/Tooltip',
+  title: 'Content/Tooltip',
   argTypes: {
     text: { control: 'text' },
     position: {

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,93 @@
+<svg width="381" height="96" viewBox="0 0 381 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_285_520)">
+<path d="M373.156 76.0002V23.2002H380.596V76.0002H373.156Z" fill="black"/>
+<path d="M337.727 77.0402C334.847 77.0402 332.234 76.7202 329.887 76.0802C327.54 75.4935 325.487 74.6135 323.727 73.4402C321.967 72.2135 320.474 70.7469 319.247 69.0402C318.074 67.3335 317.167 65.3869 316.527 63.2002C315.94 61.0135 315.647 58.5869 315.647 55.9202V23.2002H323.007V55.6802C323.007 58.8802 323.567 61.5735 324.687 63.7602C325.807 65.8935 327.46 67.5202 329.647 68.6402C331.834 69.7602 334.527 70.3202 337.727 70.3202C341.034 70.3202 343.754 69.7869 345.887 68.7202C348.074 67.6002 349.7 65.9469 350.767 63.7602C351.887 61.5735 352.447 58.8802 352.447 55.6802V23.2002H359.727V55.9202C359.727 62.6402 357.86 67.8402 354.127 71.5202C350.394 75.2002 344.927 77.0402 337.727 77.0402Z" fill="black"/>
+<path d="M268.191 77.0396C265.311 77.0396 262.751 76.7196 260.511 76.0796C258.271 75.4929 256.404 74.6396 254.911 73.5196C253.417 72.3463 252.271 70.9596 251.471 69.3596C250.671 67.7596 250.244 65.9996 250.191 64.0796L256.351 62.4796C256.244 64.2396 256.671 65.7863 257.631 67.1196C258.644 68.3996 260.057 69.3863 261.871 70.0796C263.737 70.7729 265.977 71.1196 268.591 71.1196C271.737 71.1196 274.164 70.5863 275.871 69.5196C277.631 68.4529 278.511 66.9863 278.511 65.1196C278.511 63.6263 278.031 62.4796 277.071 61.6796C276.111 60.8263 274.777 60.1596 273.071 59.6796C271.417 59.1463 269.444 58.6663 267.151 58.2396C265.231 57.8129 263.311 57.3329 261.391 56.7996C259.471 56.2663 257.711 55.5729 256.111 54.7196C254.564 53.8129 253.311 52.6396 252.351 51.1996C251.391 49.7596 250.911 47.9729 250.911 45.8396C250.911 43.3329 251.577 41.1729 252.911 39.3596C254.244 37.5463 256.137 36.1329 258.591 35.1196C261.044 34.1063 263.977 33.5996 267.391 33.5996C270.804 33.5996 273.711 34.1329 276.111 35.1996C278.511 36.2129 280.404 37.6529 281.791 39.5196C283.177 41.3863 283.951 43.5729 284.111 46.0796L277.791 47.6796C277.737 45.9196 277.257 44.4263 276.351 43.1996C275.497 41.9729 274.271 41.0663 272.671 40.4796C271.071 39.8396 269.204 39.5196 267.071 39.5196C264.244 39.5196 262.004 40.0529 260.351 41.1196C258.697 42.1863 257.871 43.6529 257.871 45.5196C257.871 46.9063 258.351 48.0263 259.311 48.8796C260.324 49.7329 261.684 50.3996 263.391 50.8796C265.097 51.3596 266.991 51.8396 269.071 52.3196C271.204 52.7463 273.231 53.2263 275.151 53.7596C277.124 54.2929 278.884 54.9863 280.431 55.8396C281.977 56.6929 283.204 57.8396 284.111 59.2796C285.017 60.6663 285.471 62.4529 285.471 64.6396C285.471 67.3596 284.751 69.6529 283.311 71.5196C281.871 73.3329 279.844 74.7196 277.231 75.6796C274.671 76.5863 271.657 77.0396 268.191 77.0396Z" fill="black"/>
+<path d="M239.093 39.04L238.053 20H245.013L243.973 39.04H239.093Z" fill="black"/>
+<path d="M225.008 76.8003C221.168 76.8003 218.314 75.7603 216.448 73.6803C214.581 71.6003 213.648 68.4269 213.648 64.1603V40.7203H207.408L207.488 34.6403H211.408C212.741 34.6403 213.701 34.4003 214.288 33.9203C214.928 33.4403 215.301 32.6403 215.408 31.5203L216.208 25.2803H220.688V34.6403H232.608V40.8003H220.688V64.0003C220.688 66.1336 221.168 67.6803 222.128 68.6403C223.141 69.5469 224.581 70.0003 226.448 70.0003C227.461 70.0003 228.501 69.8669 229.568 69.6003C230.688 69.3336 231.781 68.8003 232.848 68.0003V75.2803C231.301 75.8669 229.861 76.2669 228.528 76.4803C227.248 76.6936 226.074 76.8003 225.008 76.8003Z" fill="black"/>
+<path d="M184.731 77.0396C181.478 77.0396 178.598 76.5596 176.091 75.5996C173.638 74.5863 171.558 73.1463 169.851 71.2796C168.145 69.4129 166.865 67.1996 166.011 64.6396C165.158 62.0796 164.731 59.1996 164.731 55.9996C164.731 52.7463 165.158 49.7596 166.011 47.0396C166.865 44.3196 168.118 41.9463 169.771 39.9196C171.425 37.8929 173.451 36.3463 175.851 35.2796C178.251 34.1596 180.998 33.5996 184.091 33.5996C186.811 33.5996 189.291 34.0529 191.531 34.9596C193.771 35.8663 195.665 37.2796 197.211 39.1996C198.811 41.0663 200.011 43.4396 200.811 46.3196C201.611 49.1463 201.931 52.4796 201.771 56.3196L169.291 56.5596V51.5996L197.371 51.3596L194.891 54.7196C195.158 51.3596 194.838 48.5863 193.931 46.3996C193.025 44.2129 191.718 42.5596 190.011 41.4396C188.358 40.3196 186.385 39.7596 184.091 39.7596C181.638 39.7596 179.478 40.3996 177.611 41.6796C175.745 42.9596 174.305 44.7996 173.291 47.1996C172.331 49.5996 171.851 52.5063 171.851 55.9196C171.851 60.8263 172.945 64.5863 175.131 67.1996C177.318 69.7596 180.571 71.0396 184.891 71.0396C186.545 71.0396 187.985 70.8529 189.211 70.4796C190.491 70.0529 191.558 69.4929 192.411 68.7996C193.318 68.0529 194.038 67.1996 194.571 66.2396C195.158 65.2796 195.611 64.2396 195.931 63.1196L202.331 64.6396C201.851 66.5596 201.105 68.2929 200.091 69.8396C199.131 71.3329 197.905 72.6129 196.411 73.6796C194.971 74.7463 193.291 75.5729 191.371 76.1596C189.451 76.7463 187.238 77.0396 184.731 77.0396Z" fill="black"/>
+<path d="M128 76.0002V23.2002H135.36V76.0002H128ZM130.4 76.0002V69.6002H160V76.0002H130.4Z" fill="black"/>
+<g clip-path="url(#clip1_285_520)">
+<g filter="url(#filter0_n_285_520)">
+<path d="M0 8C0 3.58172 3.58172 0 8 0H72C85.2548 0 96 10.7452 96 24V88C96 92.4183 92.4183 96 88 96H0V8Z" fill="#6270ED"/>
+<path d="M0 8C0 3.58172 3.58172 0 8 0H72C85.2548 0 96 10.7452 96 24V88C96 92.4183 92.4183 96 88 96H0V8Z" fill="url(#paint0_linear_285_520)"/>
+</g>
+<g filter="url(#filter1_n_285_520)">
+<path d="M24 54L48 96H0L24 54Z" fill="#01CE8A"/>
+<path d="M24 54L48 96H0L24 54Z" fill="url(#paint1_linear_285_520)"/>
+</g>
+<g filter="url(#filter2_n_285_520)">
+<path d="M96 24C96 37.2548 85.2548 48 72 48C58.7452 48 48 37.2548 48 24C48 10.7452 58.7452 0 72 0C85.2548 0 96 10.7452 96 24Z" fill="#FF9900"/>
+<path d="M96 24C96 37.2548 85.2548 48 72 48C58.7452 48 48 37.2548 48 24C48 10.7452 58.7452 0 72 0C85.2548 0 96 10.7452 96 24Z" fill="url(#paint2_linear_285_520)"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_n_285_520" x="0" y="0" width="96" height="96" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="1 1" stitchTiles="stitch" numOctaves="3" result="noise" seed="5108" />
+<feColorMatrix in="noise" type="luminanceToAlpha" result="alphaNoise" />
+<feComponentTransfer in="alphaNoise" result="coloredNoise1">
+<feFuncA type="discrete" tableValues="0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "/>
+</feComponentTransfer>
+<feComposite operator="in" in2="shape" in="coloredNoise1" result="noise1Clipped" />
+<feFlood flood-color="rgba(0, 0, 0, 0.1)" result="color1Flood" />
+<feComposite operator="in" in2="noise1Clipped" in="color1Flood" result="color1" />
+<feMerge result="effect1_noise_285_520">
+<feMergeNode in="shape" />
+<feMergeNode in="color1" />
+</feMerge>
+</filter>
+<filter id="filter1_n_285_520" x="0" y="54" width="48" height="42" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="1 1" stitchTiles="stitch" numOctaves="3" result="noise" seed="5108" />
+<feColorMatrix in="noise" type="luminanceToAlpha" result="alphaNoise" />
+<feComponentTransfer in="alphaNoise" result="coloredNoise1">
+<feFuncA type="discrete" tableValues="0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "/>
+</feComponentTransfer>
+<feComposite operator="in" in2="shape" in="coloredNoise1" result="noise1Clipped" />
+<feFlood flood-color="rgba(0, 0, 0, 0.1)" result="color1Flood" />
+<feComposite operator="in" in2="noise1Clipped" in="color1Flood" result="color1" />
+<feMerge result="effect1_noise_285_520">
+<feMergeNode in="shape" />
+<feMergeNode in="color1" />
+</feMerge>
+</filter>
+<filter id="filter2_n_285_520" x="48" y="0" width="48" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="1 1" stitchTiles="stitch" numOctaves="3" result="noise" seed="5108" />
+<feColorMatrix in="noise" type="luminanceToAlpha" result="alphaNoise" />
+<feComponentTransfer in="alphaNoise" result="coloredNoise1">
+<feFuncA type="discrete" tableValues="0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "/>
+</feComponentTransfer>
+<feComposite operator="in" in2="shape" in="coloredNoise1" result="noise1Clipped" />
+<feFlood flood-color="rgba(0, 0, 0, 0.1)" result="color1Flood" />
+<feComposite operator="in" in2="noise1Clipped" in="color1Flood" result="color1" />
+<feMerge result="effect1_noise_285_520">
+<feMergeNode in="shape" />
+<feMergeNode in="color1" />
+</feMerge>
+</filter>
+<linearGradient id="paint0_linear_285_520" x1="48" y1="48" x2="96" y2="-1.21043e-06" gradientUnits="userSpaceOnUse">
+<stop stop-color="#666666" stop-opacity="0"/>
+<stop offset="1" stop-opacity="0.25"/>
+</linearGradient>
+<linearGradient id="paint1_linear_285_520" x1="24" y1="75" x2="44.8142" y2="51.2124" gradientUnits="userSpaceOnUse">
+<stop stop-color="#666666" stop-opacity="0"/>
+<stop offset="1" stop-opacity="0.25"/>
+</linearGradient>
+<linearGradient id="paint2_linear_285_520" x1="72" y1="24" x2="96" y2="-6.05216e-07" gradientUnits="userSpaceOnUse">
+<stop stop-color="#666666" stop-opacity="0"/>
+<stop offset="1" stop-opacity="0.25"/>
+</linearGradient>
+<clipPath id="clip0_285_520">
+<rect width="381" height="96" fill="white"/>
+</clipPath>
+<clipPath id="clip1_285_520">
+<rect width="96" height="96" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/docs/utilities/Flex/Flex.docs.mdx
+++ b/docs/utilities/Flex/Flex.docs.mdx
@@ -1,0 +1,310 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/Flex" />
+
+export const Box = ({ children, style = {} }) => (
+  <div style={{
+    padding: '8px 12px',
+    background: 'var(--lui-color-primary-background-container)',
+    borderRadius: '4px',
+    fontSize: '12px',
+    fontWeight: '600',
+    color: 'var(--lui-color-neutral-text-inverse)',
+    flexShrink: 0,
+    ...style,
+  }}>
+    {children}
+  </div>
+);
+
+export const Demo = ({ label, css, children }) => (
+  <div style={{
+    border: '1px solid var(--lui-color-neutral-border-subtle)',
+    borderRadius: '8px',
+    overflow: 'hidden',
+  }}>
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: '8px 14px',
+      background: 'var(--lui-color-neutral-background-surface)',
+      borderBottom: '1px solid var(--lui-color-neutral-border-subtle)',
+    }}>
+      <code style={{ fontSize: '13px', fontWeight: '700' }}>.{label}</code>
+      <code style={{ fontSize: '11px', color: 'var(--lui-color-neutral-text-caption)' }}>{css}</code>
+    </div>
+    <div style={{
+      padding: '16px',
+      background: 'var(--lui-color-neutral-background-container)',
+      minHeight: '60px',
+    }}>
+      {children}
+    </div>
+  </div>
+);
+
+export const Section = ({ title, children }) => (
+  <div style={{ marginBottom: '32px' }}>
+    <h3 style={{ fontSize: '14px', fontWeight: '600', marginBottom: '8px', color: 'var(--lui-color-neutral-text-heading)' }}>{title}</h3>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>{children}</div>
+  </div>
+);
+
+# Flex Utilities
+
+Classes utilitárias de flexbox geradas em `packages/styles/src/utilities/_flex.scss` e incluídas no bundle `letsui.css`. Cobrem display, direção, wrap, alinhamento e grow/shrink.
+
+```html
+<!-- Exemplo de uso direto no HTML -->
+<div class="flex flex-col items-center justify-between" style="gap: 16px">
+  <div>Item A</div>
+  <div>Item B</div>
+</div>
+```
+
+---
+
+<Section title="Display">
+  <Demo label="flex" css="display: flex">
+    <div style={{ display: 'flex', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="inline-flex" css="display: inline-flex">
+    <div style={{ display: 'inline-flex', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Flex Direction">
+  <Demo label="flex-row" css="flex-direction: row">
+    <div style={{ display: 'flex', flexDirection: 'row', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-row-reverse" css="flex-direction: row-reverse">
+    <div style={{ display: 'flex', flexDirection: 'row-reverse', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-col" css="flex-direction: column">
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-col-reverse" css="flex-direction: column-reverse">
+    <div style={{ display: 'flex', flexDirection: 'column-reverse', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Flex Wrap">
+  <Demo label="flex-wrap" css="flex-wrap: wrap">
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', width: '200px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-nowrap" css="flex-wrap: nowrap">
+    <div style={{ display: 'flex', flexWrap: 'nowrap', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-wrap-reverse" css="flex-wrap: wrap-reverse">
+    <div style={{ display: 'flex', flexWrap: 'wrap-reverse', gap: '8px', width: '200px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Justify Content">
+  <Demo label="justify-start" css="justify-content: flex-start">
+    <div style={{ display: 'flex', justifyContent: 'flex-start', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="justify-center" css="justify-content: center">
+    <div style={{ display: 'flex', justifyContent: 'center', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="justify-end" css="justify-content: flex-end">
+    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="justify-between" css="justify-content: space-between">
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="justify-around" css="justify-content: space-around">
+    <div style={{ display: 'flex', justifyContent: 'space-around', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="justify-evenly" css="justify-content: space-evenly">
+    <div style={{ display: 'flex', justifyContent: 'space-evenly', gap: '8px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Align Items">
+  <Demo label="items-start" css="align-items: flex-start">
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', height: '64px' }}>
+      <Box>1</Box><Box style={{ height: '40px' }}>2</Box><Box style={{ height: '24px' }}>3</Box>
+    </div>
+  </Demo>
+  <Demo label="items-center" css="align-items: center">
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', height: '64px' }}>
+      <Box>1</Box><Box style={{ height: '40px' }}>2</Box><Box style={{ height: '24px' }}>3</Box>
+    </div>
+  </Demo>
+  <Demo label="items-end" css="align-items: flex-end">
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px', height: '64px' }}>
+      <Box>1</Box><Box style={{ height: '40px' }}>2</Box><Box style={{ height: '24px' }}>3</Box>
+    </div>
+  </Demo>
+  <Demo label="items-stretch" css="align-items: stretch">
+    <div style={{ display: 'flex', alignItems: 'stretch', gap: '8px', height: '64px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box>
+    </div>
+  </Demo>
+  <Demo label="items-baseline" css="align-items: baseline">
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: '8px' }}>
+      <Box style={{ fontSize: '20px' }}>A</Box><Box style={{ fontSize: '12px' }}>B</Box><Box style={{ fontSize: '16px' }}>C</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Align Content">
+  <Demo label="content-start" css="align-content: flex-start">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignContent: 'flex-start', gap: '8px', height: '100px', width: '180px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+  <Demo label="content-center" css="align-content: center">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignContent: 'center', gap: '8px', height: '100px', width: '180px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+  <Demo label="content-end" css="align-content: flex-end">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignContent: 'flex-end', gap: '8px', height: '100px', width: '180px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+  <Demo label="content-between" css="align-content: space-between">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignContent: 'space-between', gap: '8px', height: '100px', width: '180px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+  <Demo label="content-around" css="align-content: space-around">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignContent: 'space-around', gap: '8px', height: '100px', width: '180px' }}>
+      <Box>1</Box><Box>2</Box><Box>3</Box><Box>4</Box><Box>5</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Align Self">
+  <Demo label="self-start" css="align-self: flex-start">
+    <div style={{ display: 'flex', gap: '8px', height: '64px', alignItems: 'stretch' }}>
+      <Box>A</Box>
+      <Box style={{ alignSelf: 'flex-start' }}>self-start</Box>
+      <Box>C</Box>
+    </div>
+  </Demo>
+  <Demo label="self-center" css="align-self: center">
+    <div style={{ display: 'flex', gap: '8px', height: '64px', alignItems: 'stretch' }}>
+      <Box>A</Box>
+      <Box style={{ alignSelf: 'center' }}>self-center</Box>
+      <Box>C</Box>
+    </div>
+  </Demo>
+  <Demo label="self-end" css="align-self: flex-end">
+    <div style={{ display: 'flex', gap: '8px', height: '64px', alignItems: 'stretch' }}>
+      <Box>A</Box>
+      <Box style={{ alignSelf: 'flex-end' }}>self-end</Box>
+      <Box>C</Box>
+    </div>
+  </Demo>
+  <Demo label="self-stretch" css="align-self: stretch">
+    <div style={{ display: 'flex', gap: '8px', height: '64px', alignItems: 'flex-start' }}>
+      <Box>A</Box>
+      <Box style={{ alignSelf: 'stretch' }}>self-stretch</Box>
+      <Box>C</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Flex Grow">
+  <Demo label="flex-grow-0" css="flex-grow: 0">
+    <div style={{ display: 'flex', gap: '8px' }}>
+      <Box style={{ flexGrow: 0 }}>grow-0</Box>
+      <Box style={{ flexGrow: 1, background: 'var(--lui-color-neutral-background-container)', color: 'var(--lui-color-neutral-text-body)', border: '1px dashed var(--lui-color-neutral-border-subtle)' }}>outro</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-grow-1" css="flex-grow: 1">
+    <div style={{ display: 'flex', gap: '8px' }}>
+      <Box style={{ flexGrow: 1 }}>grow-1</Box>
+      <Box>fixo</Box>
+    </div>
+  </Demo>
+</Section>
+
+<Section title="Flex Shrink">
+  <Demo label="flex-shrink-0" css="flex-shrink: 0">
+    <div style={{ display: 'flex', gap: '8px', width: '200px', overflow: 'hidden' }}>
+      <Box style={{ flexShrink: 0, width: '120px' }}>shrink-0</Box>
+      <Box style={{ minWidth: '120px', flexShrink: 1 }}>shrinks</Box>
+    </div>
+  </Demo>
+  <Demo label="flex-shrink-1" css="flex-shrink: 1">
+    <div style={{ display: 'flex', gap: '8px', width: '200px', overflow: 'hidden' }}>
+      <Box style={{ flexShrink: 1, minWidth: '80px' }}>shrink-1</Box>
+      <Box style={{ flexShrink: 1, minWidth: '80px' }}>shrink-1</Box>
+    </div>
+  </Demo>
+</Section>
+
+---
+
+## Referência rápida
+
+| Classe              | Propriedade CSS                     |
+|---------------------|-------------------------------------|
+| `.flex`             | `display: flex`                     |
+| `.inline-flex`      | `display: inline-flex`              |
+| `.flex-row`         | `flex-direction: row`               |
+| `.flex-row-reverse` | `flex-direction: row-reverse`       |
+| `.flex-col`         | `flex-direction: column`            |
+| `.flex-col-reverse` | `flex-direction: column-reverse`    |
+| `.flex-wrap`        | `flex-wrap: wrap`                   |
+| `.flex-nowrap`      | `flex-wrap: nowrap`                 |
+| `.flex-wrap-reverse`| `flex-wrap: wrap-reverse`           |
+| `.justify-start`    | `justify-content: flex-start`       |
+| `.justify-center`   | `justify-content: center`           |
+| `.justify-end`      | `justify-content: flex-end`         |
+| `.justify-between`  | `justify-content: space-between`    |
+| `.justify-around`   | `justify-content: space-around`     |
+| `.justify-evenly`   | `justify-content: space-evenly`     |
+| `.items-start`      | `align-items: flex-start`           |
+| `.items-center`     | `align-items: center`               |
+| `.items-end`        | `align-items: flex-end`             |
+| `.items-stretch`    | `align-items: stretch`              |
+| `.items-baseline`   | `align-items: baseline`             |
+| `.content-start`    | `align-content: flex-start`         |
+| `.content-center`   | `align-content: center`             |
+| `.content-end`      | `align-content: flex-end`           |
+| `.content-between`  | `align-content: space-between`      |
+| `.content-around`   | `align-content: space-around`       |
+| `.self-start`       | `align-self: flex-start`            |
+| `.self-center`      | `align-self: center`                |
+| `.self-end`         | `align-self: flex-end`              |
+| `.self-stretch`     | `align-self: stretch`               |
+| `.flex-grow-0`      | `flex-grow: 0`                      |
+| `.flex-grow-1`      | `flex-grow: 1`                      |
+| `.flex-shrink-0`    | `flex-shrink: 0`                    |
+| `.flex-shrink-1`    | `flex-shrink: 1`                    |

--- a/docs/utilities/Functions/Functions.docs.mdx
+++ b/docs/utilities/Functions/Functions.docs.mdx
@@ -1,0 +1,342 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/Functions" />
+
+export const colorFns = [
+  {
+    fn: 'bg($category, $variant)',
+    desc: 'Cor de fundo semântica',
+    params: [
+      { label: '$category', values: ['surface', 'container'] },
+      { label: '$variant', values: ['primary', 'secondary', 'info', 'danger', 'success', 'caution', 'neutral', 'overlay*'] },
+    ],
+    note: '* overlay disponível apenas em container',
+  },
+  {
+    fn: 'text($variant)',
+    desc: 'Cor de texto semântica',
+    params: [
+      { label: '$variant', values: ['heading', 'body', 'caption', 'primary', 'inverse', 'error', 'link', 'link-visited'] },
+    ],
+  },
+  {
+    fn: 'stroke($variant, $category?)',
+    desc: 'Cor de borda semântica',
+    params: [
+      { label: '$variant', values: ['primary', 'secondary', 'caution', 'danger', 'info', 'success', 'neutral'] },
+      { label: '$category', values: ['default (padrão)', 'subtle', 'hover', 'pressed'] },
+    ],
+  },
+  {
+    fn: 'icon($variant)',
+    desc: 'Cor de ícone semântica',
+    params: [
+      { label: '$variant', values: ['primary', 'secondary', 'info', 'danger', 'success', 'caution', 'neutral', 'inverse'] },
+    ],
+  },
+  {
+    fn: 'color($category, $scale)',
+    desc: 'Cor primitiva da paleta',
+    params: [
+      { label: '$category', values: ['primary', 'secondary', 'blue', 'gray', 'green', 'orange', 'red', 'violet'] },
+      { label: '$scale', values: ['1', '2', '3', '4', '5', '6', '7', '8'] },
+    ],
+  },
+  {
+    fn: 'hover($variant)',
+    desc: 'Fundo de estado hover',
+    params: [
+      { label: '$variant', values: ['primary', 'secondary', 'danger', 'success', 'neutral'] },
+    ],
+  },
+  {
+    fn: 'pressed($variant)',
+    desc: 'Fundo de estado pressed/active',
+    params: [
+      { label: '$variant', values: ['primary', 'secondary', 'danger', 'success', 'neutral'] },
+    ],
+  },
+];
+
+export const borderFns = [
+  {
+    fn: 'radius($size)',
+    desc: 'Border radius',
+    rows: [
+      { val: 'none',   desc: 'Sem arredondamento' },
+      { val: 'xs',     desc: 'Tags, badges, chips' },
+      { val: 'sm',     desc: 'Botões, inputs' },
+      { val: 'md',     desc: 'Cards, modais' },
+      { val: 'lg',     desc: 'Drawers, superfícies grandes' },
+      { val: 'xl',     desc: 'Contêineres de destaque' },
+      { val: 'circle', desc: 'Avatares, ícones circulares' },
+    ],
+  },
+  {
+    fn: 'width($size)',
+    desc: 'Border width',
+    rows: [
+      { val: '0', desc: 'Sem borda — 0' },
+      { val: '1', desc: 'Borda padrão — 1px' },
+      { val: '2', desc: 'Ênfase/foco — 2px' },
+    ],
+  },
+];
+
+export const spacingFns = [
+  { fn: 'fixed($size)', desc: 'Espaçamento fixo em px', values: ['0', '8', '16', '24', '32', '40'] },
+  { fn: 'fluid($size)', desc: 'Espaçamento fluido com clamp()', values: ['2', '4', '8', '12', '16', '20', '24', '32', '40', '48', '56', '64', '72', '80'] },
+];
+
+export const typographyFns = [
+  { fn: 'font($font)',             prop: 'font-family',    values: ['heading', 'body'] },
+  { fn: 'size($size)',             prop: 'font-size',      values: ['3xl', '2xl', '1xl', 'lg', 'md', 'sm', '1xs', '2xs', '3xs'] },
+  { fn: 'weight($weight)',         prop: 'font-weight',    values: ['regular', 'medium', 'semibold', 'bold'] },
+  { fn: 'line-height($lh)',        prop: 'line-height',    values: ['heading', 'body'] },
+  { fn: 'case($case)',             prop: 'text-transform', values: ['none', 'lowercase', 'uppercase'] },
+  { fn: 'decoration($decoration)', prop: 'text-decoration',values: ['none', 'underline', 'line-through'] },
+];
+
+export const stateFns = [
+  { fn: 'focus-ring($variant)', desc: 'Box-shadow de foco', values: ['primary', 'secondary', 'danger', 'success', 'neutral'] },
+  { fn: 'elevation($layer)',    desc: 'Box-shadow de elevação', values: ['base', 'hovered', 'floating', 'overlay'] },
+  { fn: 'opacity($category)',   desc: 'Opacidade semântica', values: ['disabled', 'hidden', 'visible'] },
+  { fn: 'breakpoint($name)',    desc: 'Valor de breakpoint responsivo', values: ['1xs (320px)', 'sm (768px)', 'md (1024px)', 'lg (1280px)', '1xl (1440px)'] },
+];
+
+# Functions
+
+Funções SCSS definidas em `packages/styles/src/utilities/_functions.scss`. Use-as nos componentes para acessar tokens de design de forma segura — cada função valida o argumento e lança um erro de compilação se o valor não existir no mapa de tokens.
+
+```scss
+// No arquivo de componente
+@use '../utilities/functions' as *;
+
+.my-component {
+  background-color: bg(surface, primary);
+  color: text(body);
+  border-radius: radius(sm);
+  padding: fluid(16);
+}
+```
+
+---
+
+## Cores
+
+<div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '32px' }}>
+  {colorFns.map(({ fn, desc, params, note }) => (
+    <div key={fn} style={{
+      padding: '16px',
+      background: 'var(--lui-color-neutral-background-surface)',
+      border: '1px solid var(--lui-color-neutral-border-subtle)',
+      borderRadius: '8px',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', marginBottom: '10px' }}>
+        <code style={{ fontSize: '13px', fontWeight: '600' }}>{fn}</code>
+        <span style={{ fontSize: '12px', color: 'var(--lui-color-neutral-text-caption)' }}>{desc}</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {params.map(({ label, values }) => (
+          <div key={label} style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', flexWrap: 'wrap' }}>
+            <code style={{ fontSize: '11px', color: 'var(--lui-color-neutral-text-caption)', flexShrink: 0, minWidth: '80px' }}>{label}</code>
+            <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+              {values.map(v => (
+                <code key={v} style={{
+                  fontSize: '11px',
+                  padding: '1px 6px',
+                  background: 'var(--lui-color-neutral-background-container)',
+                  borderRadius: '4px',
+                }}>{v}</code>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      {note && <p style={{ fontSize: '11px', color: 'var(--lui-color-neutral-text-caption)', margin: '8px 0 0' }}>{note}</p>}
+    </div>
+  ))}
+</div>
+
+### Exemplo de uso — cores
+
+```scss
+.alert--danger {
+  background-color: bg(container, danger);
+  border-color: stroke(danger);
+  color: text(body);
+
+  .alert__icon { color: icon(danger); }
+}
+
+.btn--primary {
+  background-color: bg(container, primary);
+  color: text(inverse);
+
+  &:hover  { background-color: hover(primary); }
+  &:active { background-color: pressed(primary); }
+}
+```
+
+---
+
+## Borda
+
+<div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '32px' }}>
+  {borderFns.map(({ fn, desc, rows }) => (
+    <div key={fn} style={{
+      padding: '16px',
+      background: 'var(--lui-color-neutral-background-surface)',
+      border: '1px solid var(--lui-color-neutral-border-subtle)',
+      borderRadius: '8px',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', marginBottom: '10px' }}>
+        <code style={{ fontSize: '13px', fontWeight: '600' }}>{fn}</code>
+        <span style={{ fontSize: '12px', color: 'var(--lui-color-neutral-text-caption)' }}>{desc}</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {rows.map(({ val, desc: d }) => (
+          <div key={val} style={{
+            display: 'grid',
+            gridTemplateColumns: '80px 1fr',
+            gap: '8px',
+            alignItems: 'center',
+          }}>
+            <code style={{ fontSize: '11px', padding: '1px 6px', background: 'var(--lui-color-neutral-background-container)', borderRadius: '4px' }}>{val}</code>
+            <span style={{ fontSize: '12px', color: 'var(--lui-color-neutral-text-caption)' }}>{d}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  ))}
+</div>
+
+```scss
+.card    { border-radius: radius(md); border-width: width(1); }
+.avatar  { border-radius: radius(circle); }
+.focused { border-width: width(2); }
+```
+
+---
+
+## Espaçamento
+
+<div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '32px' }}>
+  {spacingFns.map(({ fn, desc, values }) => (
+    <div key={fn} style={{
+      padding: '16px',
+      background: 'var(--lui-color-neutral-background-surface)',
+      border: '1px solid var(--lui-color-neutral-border-subtle)',
+      borderRadius: '8px',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', marginBottom: '10px' }}>
+        <code style={{ fontSize: '13px', fontWeight: '600' }}>{fn}</code>
+        <span style={{ fontSize: '12px', color: 'var(--lui-color-neutral-text-caption)' }}>{desc}</span>
+      </div>
+      <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+        {values.map(v => (
+          <code key={v} style={{
+            fontSize: '11px',
+            padding: '1px 6px',
+            background: 'var(--lui-color-neutral-background-container)',
+            borderRadius: '4px',
+          }}>{v}</code>
+        ))}
+      </div>
+    </div>
+  ))}
+</div>
+
+```scss
+.section { padding: fluid(40); }
+.card    { padding: fluid(24); gap: fixed(16); }
+```
+
+> Use `fluid()` para espaçamentos de layout (margens, gaps entre blocos) e `fixed()` para espaçamentos internos de componentes que não devem mudar com o viewport.
+
+---
+
+## Tipografia
+
+<div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '32px' }}>
+  {typographyFns.map(({ fn, prop, values }) => (
+    <div key={fn} style={{
+      display: 'grid',
+      gridTemplateColumns: '220px 160px 1fr',
+      alignItems: 'center',
+      gap: '16px',
+      padding: '10px 16px',
+      background: 'var(--lui-color-neutral-background-surface)',
+      border: '1px solid var(--lui-color-neutral-border-subtle)',
+      borderRadius: '6px',
+    }}>
+      <code style={{ fontSize: '12px', fontWeight: '600' }}>{fn}</code>
+      <span style={{ fontSize: '11px', color: 'var(--lui-color-neutral-text-caption)' }}>{prop}</span>
+      <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+        {values.map(v => (
+          <code key={v} style={{
+            fontSize: '11px',
+            padding: '1px 6px',
+            background: 'var(--lui-color-neutral-background-container)',
+            borderRadius: '4px',
+          }}>{v}</code>
+        ))}
+      </div>
+    </div>
+  ))}
+</div>
+
+```scss
+.heading--title {
+  font-family: font(heading);
+  font-size: size(2xl);
+  font-weight: weight(bold);
+  line-height: line-height(heading);
+}
+```
+
+> Para aplicar escalas tipográficas completas, prefira o mixin `font-scale($scale-name)`.
+
+---
+
+## Estados e elevação
+
+<div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '32px' }}>
+  {stateFns.map(({ fn, desc, values }) => (
+    <div key={fn} style={{
+      padding: '12px 16px',
+      background: 'var(--lui-color-neutral-background-surface)',
+      border: '1px solid var(--lui-color-neutral-border-subtle)',
+      borderRadius: '6px',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', marginBottom: '6px' }}>
+        <code style={{ fontSize: '13px', fontWeight: '600' }}>{fn}</code>
+        <span style={{ fontSize: '12px', color: 'var(--lui-color-neutral-text-caption)' }}>{desc}</span>
+      </div>
+      <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+        {values.map(v => (
+          <code key={v} style={{
+            fontSize: '11px',
+            padding: '1px 6px',
+            background: 'var(--lui-color-neutral-background-container)',
+            borderRadius: '4px',
+          }}>{v}</code>
+        ))}
+      </div>
+    </div>
+  ))}
+</div>
+
+```scss
+.modal   { box-shadow: elevation(overlay); }
+.tooltip { box-shadow: elevation(floating); }
+
+.btn:focus-visible { box-shadow: focus-ring(primary); }
+.btn:disabled      { opacity: opacity(disabled); }
+
+@media (min-width: breakpoint(md)) {
+  .sidebar { display: block; }
+}
+```
+
+> Para responsividade, prefira os mixins `media-up()` e `media-down()` em vez de chamar `breakpoint()` diretamente.

--- a/docs/utilities/Mixins/Mixins.docs.mdx
+++ b/docs/utilities/Mixins/Mixins.docs.mdx
@@ -1,0 +1,241 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/Mixins" />
+
+export const mixins = [
+  {
+    name: 'flex',
+    signature: '@include flex($direction, $align, $justify, $gap, $wrap)',
+    desc: 'Shorthand para configurar um container flexbox em uma única linha.',
+    params: [
+      { name: '$direction', default: 'row',      values: 'row | row-reverse | column | column-reverse' },
+      { name: '$align',     default: 'center',   values: 'flex-start | center | flex-end | stretch | baseline' },
+      { name: '$justify',   default: 'flex-start', values: 'flex-start | center | flex-end | space-between | space-around' },
+      { name: '$gap',       default: '0',        values: 'qualquer valor de espaçamento' },
+      { name: '$wrap',      default: 'nowrap',   values: 'nowrap | wrap | wrap-reverse' },
+    ],
+    example: `@include flex(row, center, space-between, fluid(16));`,
+  },
+  {
+    name: 'center',
+    signature: '@include center($axis)',
+    desc: 'Centraliza o conteúdo via flexbox no eixo indicado.',
+    params: [
+      { name: '$axis', default: 'both', values: 'both | x | y' },
+    ],
+    example: `// Centralizar em ambos os eixos
+@include center;
+
+// Apenas horizontalmente
+@include center(x);
+
+// Apenas verticalmente
+@include center(y);`,
+  },
+  {
+    name: 'center-absolute',
+    signature: '@include center-absolute',
+    desc: 'Centraliza absolutamente um elemento em relação ao seu pai com position: absolute.',
+    params: [],
+    example: `.overlay__spinner {
+  position: relative; // no pai
+
+  .spinner {
+    @include center-absolute;
+  }
+}`,
+  },
+  {
+    name: 'media-up',
+    signature: '@include media-up($breakpoint)',
+    desc: 'Aplica estilos a partir de um breakpoint mínimo (mobile-first).',
+    params: [
+      { name: '$breakpoint', default: '—', values: '1xs | sm | md | lg | 1xl' },
+    ],
+    example: `.sidebar {
+  display: none;
+
+  @include media-up(md) {
+    display: block;
+  }
+}`,
+  },
+  {
+    name: 'media-down',
+    signature: '@include media-down($breakpoint)',
+    desc: 'Aplica estilos abaixo de um breakpoint máximo.',
+    params: [
+      { name: '$breakpoint', default: '—', values: '1xs | sm | md | lg | 1xl' },
+    ],
+    example: `.nav__menu {
+  @include media-down(sm) {
+    display: none;
+  }
+}`,
+  },
+  {
+    name: 'states',
+    signature: '@include states($variant, $focus-visible, $focus?)',
+    desc: 'Aplica estados interativos completos: disabled, hover, active e focus-visible. Ideal para botões e controles interativos.',
+    params: [
+      { name: '$variant',       default: '—', values: 'primary | secondary | danger | success | neutral' },
+      { name: '$focus-visible', default: '—', values: 'primary | secondary | danger | success | neutral' },
+      { name: '$focus',         default: 'null', values: 'primary | secondary | danger | success | neutral' },
+    ],
+    example: `.btn--primary {
+  @include states(primary, primary);
+}
+
+.btn--danger {
+  @include states(danger, danger);
+}`,
+  },
+  {
+    name: 'disabled',
+    signature: '@include disabled',
+    desc: 'Aplica apenas os estilos de estado desabilitado (cursor, opacidade, text-decoration). Use quando não precisar dos outros estados do mixin states().',
+    params: [],
+    example: `.link {
+  @include disabled;
+}`,
+  },
+  {
+    name: 'focus-ring',
+    signature: '@include focus-ring($variant)',
+    desc: 'Aplica o box-shadow de foco visível ao :focus-visible do elemento.',
+    params: [
+      { name: '$variant', default: '—', values: 'primary | secondary | danger | success | neutral' },
+    ],
+    example: `.input {
+  @include focus-ring(primary);
+}`,
+  },
+  {
+    name: 'sr-only',
+    signature: '@include sr-only',
+    desc: 'Esconde visualmente o elemento mas mantém acessível para leitores de tela. Equivalente ao utilitário sr-only do Tailwind.',
+    params: [],
+    example: `.label--hidden {
+  @include sr-only;
+}`,
+  },
+  {
+    name: 'no-select',
+    signature: '@include no-select',
+    desc: 'Desabilita a seleção de texto com user-select: none.',
+    params: [],
+    example: `.btn {
+  @include no-select;
+}`,
+  },
+  {
+    name: 'font-scale',
+    signature: '@include font-scale($scale-name)',
+    desc: 'Aplica uma escala tipográfica completa (font, size, weight, line-height, case) em uma única chamada.',
+    params: [
+      { name: '$scale-name', default: '—', values: 'display | title | headline | subtitle | block-title | subheadline | overtitle | body--lg | body--md | body--sm' },
+    ],
+    example: `.page-title {
+  @include font-scale(title);
+}
+
+.section-header {
+  @include font-scale(headline);
+}
+
+.caption {
+  @include font-scale(body--sm);
+}`,
+  },
+];
+
+# Mixins
+
+Mixins SCSS definidos em `packages/styles/src/utilities/_mixins.scss`. Encapsulam padrões recorrentes de CSS para reduzir repetição e garantir consistência entre componentes.
+
+```scss
+// No arquivo de componente
+@use '../utilities/mixins' as *;
+// ou junto com functions:
+@use '../utilities/functions' as *;
+@use '../utilities/mixins' as *;
+```
+
+---
+
+<div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+  {mixins.map(({ name, signature, desc, params, example }) => (
+    <div key={name} style={{
+      border: '1px solid var(--lui-color-neutral-border-subtle)',
+      borderRadius: '8px',
+      overflow: 'hidden',
+    }}>
+      <div style={{
+        padding: '14px 16px',
+        background: 'var(--lui-color-neutral-background-surface)',
+        borderBottom: params.length > 0 || example ? '1px solid var(--lui-color-neutral-border-subtle)' : 'none',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', marginBottom: '4px' }}>
+          <code style={{ fontSize: '13px', fontWeight: '700' }}>@include {name}</code>
+        </div>
+        <p style={{ margin: '0', fontSize: '13px', color: 'var(--lui-color-neutral-text-body)' }}>{desc}</p>
+        {params.length > 0 && (
+          <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            {params.map(p => (
+              <div key={p.name} style={{ display: 'grid', gridTemplateColumns: '140px 80px 1fr', gap: '8px', fontSize: '12px', alignItems: 'start' }}>
+                <code style={{ color: 'var(--lui-color-neutral-text-body)' }}>{p.name}</code>
+                <span style={{ color: 'var(--lui-color-neutral-text-caption)', fontVariantNumeric: 'tabular-nums' }}>
+                  {p.default !== '—' ? `default: ${p.default}` : '(obrigatório)'}
+                </span>
+                <span style={{ color: 'var(--lui-color-neutral-text-caption)' }}>{p.values}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {example && (
+        <pre style={{
+          margin: 0,
+          padding: '14px 16px',
+          background: 'var(--lui-color-neutral-background-container)',
+          fontSize: '12px',
+          lineHeight: '1.6',
+          overflowX: 'auto',
+          color: 'var(--lui-color-neutral-text-body)',
+          fontFamily: 'monospace',
+        }}>{example}</pre>
+      )}
+    </div>
+  ))}
+</div>
+
+---
+
+## Breakpoints de referência
+
+Os mixins `media-up()` e `media-down()` usam internamente a função `breakpoint()`:
+
+| Nome  | Largura |
+|-------|---------|
+| `1xs` | 320px   |
+| `sm`  | 768px   |
+| `md`  | 1024px  |
+| `lg`  | 1280px  |
+| `1xl` | 1440px  |
+
+---
+
+## Escalas tipográficas para `font-scale()`
+
+| Nome          | Família  | Tamanho | Peso      | Case      |
+|---------------|----------|---------|-----------|-----------|
+| `display`     | heading  | 3xl     | regular   | none      |
+| `title`       | heading  | 2xl     | bold      | none      |
+| `headline`    | heading  | 1xl     | semibold  | none      |
+| `subtitle`    | heading  | lg      | regular   | none      |
+| `block-title` | heading  | md      | medium    | none      |
+| `subheadline` | heading  | sm      | regular   | none      |
+| `overtitle`   | heading  | 3xs     | medium    | uppercase |
+| `body--lg`    | body     | 1xs     | regular   | none      |
+| `body--md`    | body     | 2xs     | regular   | none      |
+| `body--sm`    | body     | 3xs     | regular   | none      |

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@storybook/addon-docs": "^10.1.11",
     "@storybook/addon-vitest": "^10.1.11",
     "@storybook/html-vite": "^10.1.11",
+    "@storybook/theming": "^8.6.14",
     "@terrazzo/cli": "^2.0.0-beta.4",
     "@terrazzo/plugin-css": "^2.0.0-beta.4",
     "@terrazzo/plugin-sass": "^2.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
       "markdownlint-cli2"
     ]
   },
+  "dependencies": {
+    "lets-ui-icons": "^0.1.0"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@chromatic-com/storybook": "^4.1.3",
@@ -54,7 +57,6 @@
     "@storybook/addon-docs": "^10.1.11",
     "@storybook/addon-vitest": "^10.1.11",
     "@storybook/html-vite": "^10.1.11",
-    "@storybook/theming": "^8.6.14",
     "@terrazzo/cli": "^2.0.0-beta.4",
     "@terrazzo/plugin-css": "^2.0.0-beta.4",
     "@terrazzo/plugin-sass": "^2.0.0-beta.4",
@@ -78,8 +80,5 @@
     "stylelint-config-standard-scss": "^16.0.0",
     "stylelint-scss": "^6.14.0",
     "vitest": "^4.0.16"
-  },
-  "dependencies": {
-    "lets-ui-icons": "^0.1.0"
   }
 }

--- a/packages/lets-ui-components/package.json
+++ b/packages/lets-ui-components/package.json
@@ -45,6 +45,14 @@
     "./tooltip": "./src/components/tooltip.js",
     "./textarea": "./src/components/textarea.js"
   },
+  "peerDependencies": {
+    "lets-ui-icons": ">=0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "lets-ui-icons": {
+      "optional": false
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@storybook/html-vite':
         specifier: ^10.1.11
         version: 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.0-beta.16(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))
-      '@storybook/theming':
-        specifier: ^8.6.14
-        version: 8.6.14(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@terrazzo/cli':
         specifier: ^2.0.0-beta.4
         version: 2.0.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(hono@4.12.12)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)
@@ -122,6 +119,10 @@ importers:
         version: 4.1.4(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.0-beta.16(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))
 
   packages/lets-ui-components:
+    dependencies:
+      lets-ui-icons:
+        specifier: '>=0.1.0'
+        version: 0.1.0
     devDependencies:
       '@lets-ui/styles':
         specifier: workspace:*
@@ -1433,11 +1434,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.3.5
-
-  '@storybook/theming@8.6.14':
-    resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@terrazzo/cli@2.0.0':
     resolution: {integrity: sha512-0MYaj8CMmKeWxzYcbb8iCh63aFdQ4uYMNYgeiqyKmxkpeDFGox9lzZITgSc1hBO4VTnape7PrMcRE3QUy3u7bA==}
@@ -5682,10 +5678,6 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-
-  '@storybook/theming@8.6.14(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
-    dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   '@terrazzo/cli@2.0.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(hono@4.12.12)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@storybook/html-vite':
         specifier: ^10.1.11
         version: 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.0-beta.16(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))
+      '@storybook/theming':
+        specifier: ^8.6.14
+        version: 8.6.14(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@terrazzo/cli':
         specifier: ^2.0.0-beta.4
         version: 2.0.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(hono@4.12.12)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)
@@ -1430,6 +1433,11 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.3.5
+
+  '@storybook/theming@8.6.14':
+    resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@terrazzo/cli@2.0.0':
     resolution: {integrity: sha512-0MYaj8CMmKeWxzYcbb8iCh63aFdQ4uYMNYgeiqyKmxkpeDFGox9lzZITgSc1hBO4VTnape7PrMcRE3QUy3u7bA==}
@@ -5674,6 +5682,10 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  '@storybook/theming@8.6.14(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   '@terrazzo/cli@2.0.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(hono@4.12.12)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)':


### PR DESCRIPTION
## Summary

- Add custom Let's UI brand theme to Storybook manager (`@storybook/theming` → `storybook/theming/create` — API moved in v10)
- Remove incompatible `@storybook/theming@8.6.14` package (was flagged as incompatible with Storybook 10)
- Add stories and MDX docs for Link, Shortcut, Flex, Functions, and Mixins
- Reorganize all stories into semantic category groups
- Add brand logo to public assets
- Declare `lets-ui-icons` as required `peerDependency` of `@lets-ui/components` so consumers are warned if it's missing

## Test plan

- [x] `pnpm storybook` starts without incompatible package warnings
- [x] Storybook renders with custom Let's UI brand theme (logo, colors, typography)
- [x] New stories (Link, Shortcut) and docs (Flex, Functions, Mixins) render correctly
- [x] Icon-dependent components (Alert, Icon Button, Drawer, Modal, Dropdown Menu) render icons correctly
- [x] `pnpm lint` passes with no errors
- [x] `pnpm build` passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)