### PR TITLE
refactor(components): extract targeted typography reset for Shadow DOM

### DIFF
--- a/.changeset/spicy-apes-invite.md
+++ b/.changeset/spicy-apes-invite.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+- Extracts a new `_typography-reset.scss` partial focused on typography component elements (`h1`–`h6`, `p`, and `div`), replacing the global `_reset.scss` and reducing unnecessary reset styles in the Shadow DOM.

--- a/packages/lets-ui-components/src/components/body/body.scss
+++ b/packages/lets-ui-components/src/components/body/body.scss
@@ -1,4 +1,4 @@
-@use 'packages/styles/src/reset' as *;
+@use 'packages/styles/src/typography-reset' as *;
 @use 'packages/styles/src/foundations/typography' as *;
 
 :host {

--- a/packages/lets-ui-components/src/components/heading/heading.scss
+++ b/packages/lets-ui-components/src/components/heading/heading.scss
@@ -1,4 +1,4 @@
-@use 'packages/styles/src/reset' as *;
+@use 'packages/styles/src/typography-reset' as *;
 @use 'packages/styles/src/foundations/typography' as *;
 
 :host {

--- a/packages/styles/src/_typography-reset.scss
+++ b/packages/styles/src/_typography-reset.scss
@@ -1,0 +1,14 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+div {
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  font-family: inherit;
+}


### PR DESCRIPTION
## Summary

- Extrai um novo partial `_typography-reset.scss` com reset focado nos elementos renderizados pelos componentes de tipografia (`h1`–`h6`, `p`, `div`), substituindo o uso do `_reset.scss` global — que contém mais de 90 seletores irrelevantes para o contexto de Shadow DOM.
- `lui-heading` e `lui-body` passam a importar o novo partial em seus estilos de Shadow DOM, reduzindo o CSS gerado por componente e garantindo que apenas as propriedades necessárias (`margin`, `padding`, `font-size`, `font-weight`, `font-family`) sejam resetadas.

## Test plan

- [x] Build de `@lets-ui/components` passa sem erros
- [x] `lui-heading` e `lui-body` renderizam sem margens ou padding indesejados do browser
- [x] Estilos de tipografia continuam aplicados corretamente após o reset
- [x] Nenhum outro componente é afetado pela mudança

🤖 Generated with [Claude Code](https://claude.com/claude-code)