### PR TITLE
feat(link): add slot support to lui-link

### DIFF
--- a/.changeset/true-crews-marry.md
+++ b/.changeset/true-crews-marry.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/tokens': minor
+'@lets-ui/styles': minor
+---
+
+Add slot support to lui-link, keeping label as fallback — mirrors the pattern used by lui-heading and lui-body.

--- a/packages/lets-ui-components/src/components/link/Link.docs.mdx
+++ b/packages/lets-ui-components/src/components/link/Link.docs.mdx
@@ -10,15 +10,19 @@ Componente de link navegável. Aplica a cor semântica `text(link)`, remove o su
 <Canvas of={LinkStories.Default} />
 <Controls of={LinkStories.Default} />
 
----
-
 ## Em parágrafo
 
 Links geralmente aparecem inline dentro de blocos de texto. Use a tag `<a class="link">` diretamente para embutir um link em conteúdo corrido.
 
 <Canvas of={LinkStories.InParagraph} />
 
----
+## Em slot
+
+<Canvas of={LinkStories.WithSlot} />
+
+## Em label
+
+<Canvas of={LinkStories.WithLabel} />
 
 ## Com aria-label
 
@@ -26,15 +30,11 @@ Quando o texto do link não descreve o destino com clareza (ex.: "saiba mais", "
 
 <Canvas of={LinkStories.WithAriaLabel} />
 
----
-
 ## Classe CSS (sem Web Component)
 
 A estilização de link está disponível diretamente via classe CSS `.link` em qualquer tag `<a>`, sem necessidade de usar o web component `<lui-link>`.
 
 <Canvas of={LinkStories.CSSClass} />
-
----
 
 ## Uso
 

--- a/packages/lets-ui-components/src/components/link/Link.stories.js
+++ b/packages/lets-ui-components/src/components/link/Link.stories.js
@@ -37,6 +37,11 @@ export const InParagraph = () => `
 `;
 InParagraph.storyName = 'Em parágrafo';
 
+export const WithSlot = () => `
+  <lui-link href="#">Via slot: <strong>Saiba mais</strong></lui-link>
+`;
+WithSlot.storyName = 'Via slot';
+
 export const WithAriaLabel = () => `
   <lui-link label="Leia mais" href="#" aria-label="Leia mais sobre acessibilidade"></lui-link>
 `;

--- a/packages/lets-ui-components/src/components/link/Link.stories.js
+++ b/packages/lets-ui-components/src/components/link/Link.stories.js
@@ -13,34 +13,45 @@ export default {
 
 const Template = ({ label, href, ariaLabel }) => `
   <lui-link
-    label="${label}"
     href="${href}"
     ${ariaLabel ? `aria-label="${ariaLabel}"` : ''}
-  ></lui-link>
+  >
+    ${label}
+  </lui-link>
 `;
 
 export const Default = Template.bind({});
 Default.args = {
   label: 'Saiba mais',
   href: '#',
-  ariaLabel: '',
+  ariaLabel: 'Saiba mais informações sobre o design system',
 };
 Default.storyName = 'Default';
 
 export const InParagraph = () => `
-  <p class="body--lg">
-    Ao continuar você concorda com os
-    <a class="link" href="#">termos de uso</a>
-    e com a
-    <a class="link" href="#">política de privacidade</a>.
-  </p>
+  <lui-body variant="lg">
+    Para entender mais sobre design systems, leia <lui-link href="https://www.casadocodigo.com.br/products/livro-design-system">Design System além do layout</lui-link> de Mateus Villain.
+  </lui-body>
 `;
 InParagraph.storyName = 'Em parágrafo';
 
 export const WithSlot = () => `
-  <lui-link href="#">Via slot: <strong>Saiba mais</strong></lui-link>
+  <lui-link
+    href="#"
+  >
+    Acesse sua <strong>conta</strong>
+  </lui-link>
 `;
+
 WithSlot.storyName = 'Via slot';
+
+export const WithLabel = () => `
+  <lui-link
+    label="Esqueci minha senha"
+    href="#"
+  ></lui-link>
+`;
+WithLabel.storyName = 'Via label';
 
 export const WithAriaLabel = () => `
   <lui-link label="Leia mais" href="#" aria-label="Leia mais sobre acessibilidade"></lui-link>

--- a/packages/lets-ui-components/src/components/link/link.ts
+++ b/packages/lets-ui-components/src/components/link/link.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './link.scss?inline';
 
 export class LuiLink extends LitElement {
@@ -10,9 +11,11 @@ export class LuiLink extends LitElement {
   @property({ attribute: 'aria-label' }) ariaLabel = '';
 
   render() {
-    const ariaLabel = this.ariaLabel || this.label || 'Link';
-    return html`<a class="link" href="${this.href}" aria-label="${ariaLabel}"
-      >${this.label}</a
+    return html`<a
+      class="link"
+      href="${this.href}"
+      aria-label="${ifDefined(this.ariaLabel || undefined)}"
+      ><slot>${this.label}</slot></a
     >`;
   }
 }


### PR DESCRIPTION
## Summary

- Add `<slot>` to `lui-link`, keeping `label` as fallback content — mirrors the pattern used by `lui-heading` and `lui-body`
- Fix `aria-label` to only render when explicitly provided via prop, preventing it from overriding the accessible name derived from slotted content
- Add a new **"Via slot"** story demonstrating usage with rich HTML content

## Test plan

- [x] `<lui-link label="Saiba mais" href="#">` still renders as before
- [x] `<lui-link href="#">Via slot: <strong>Saiba mais</strong></lui-link>` renders slotted content
- [x] `aria-label` is absent when not explicitly set; present when set
- [ ] Storybook: confirm new **"Via slot"** story renders correctly alongside existing stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)