### PR TITLE
feat(link): extend lui-link with full anchor attribute coverage

### DIFF
--- a/.changeset/social-meteors-try.md
+++ b/.changeset/social-meteors-try.md
@@ -1,0 +1,21 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+### Added
+
+- Extend `lui-link` with full anchor attribute coverage: `target` (default `_self`), `rel` (auto `noopener noreferrer` when `target="_blank"`), `download`, `hreflang`, and `referrerpolicy`.
+- New `external` boolean prop on `lui-link` — renders an inline SVG icon and automatically sets `target="_blank"` and `rel="noopener noreferrer"`.
+- New `size` prop on `lui-link` with `lg`, `md`, and `sm` values following the same typographic scale as `lui-body`; omitting it inherits `font-size` from context.
+- New `disabled` boolean prop on `lui-link` — removes `href`, sets `aria-disabled="true"`, and keeps the element focusable via `tabindex="0"`.
+- New `visited` boolean prop on `lui-link` — opt-in `:visited` styling, off by default to avoid unintentional exposure of browsing history.
+
+### Fixed
+
+- Remove trailing whitespace from `class` attribute of `lui-link` when `size` is not set.
+- Resolve `disabled` state on `lui-link` not applying `cursor: not-allowed` due to `pointer-events: none` blocking the cursor; navigation is now prevented by removing `href` instead.
+- Correct `aria-disabled` binding on `lui-link` — the Lit boolean attribute (`?`) was rendering `aria-disabled=""` instead of `aria-disabled="true"`, preventing CSS selector from matching.
+- Prevent hover underline from appearing on `lui-link` while `disabled` is active by scoping `:hover` to `:not([aria-disabled="true"])`.
+- Crop SVG `viewBox` on the external icon of `lui-link` to match the surrounding text size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v1.4.0
+
+### Added
+
+- Extend `lui-link` with full anchor attribute coverage: `target` (default `_self`), `rel` (auto `noopener noreferrer` when `target="_blank"`), `download`, `hreflang`, and `referrerpolicy`.
+- New `external` boolean prop on `lui-link` — renders an inline SVG icon and automatically sets `target="_blank"` and `rel="noopener noreferrer"`.
+- New `size` prop on `lui-link` with `lg`, `md`, and `sm` values following the same typographic scale as `lui-body`; omitting it inherits `font-size` from context.
+- New `disabled` boolean prop on `lui-link` — removes `href`, sets `aria-disabled="true"`, and keeps the element focusable via `tabindex="0"`.
+- New `visited` boolean prop on `lui-link` — opt-in `:visited` styling, off by default to avoid unintentional exposure of browsing history.
+
+### Fixed
+
+- Remove trailing whitespace from `class` attribute of `lui-link` when `size` is not set.
+- Resolve `disabled` state on `lui-link` not applying `cursor: not-allowed` due to `pointer-events: none` blocking the cursor; navigation is now prevented by removing `href` instead.
+- Correct `aria-disabled` binding on `lui-link` — the Lit boolean attribute (`?`) was rendering `aria-disabled=""` instead of `aria-disabled="true"`, preventing CSS selector from matching.
+- Prevent hover underline from appearing on `lui-link` while `disabled` is active by scoping `:hover` to `:not([aria-disabled="true"])`.
+- Crop SVG `viewBox` on the external icon of `lui-link` to match the surrounding text size.
+
 ## v1.3.0
 
 ### Added

--- a/packages/lets-ui-components/src/components/link/Link.docs.mdx
+++ b/packages/lets-ui-components/src/components/link/Link.docs.mdx
@@ -5,28 +5,74 @@ import * as LinkStories from './Link.stories';
 
 # Link
 
-Componente de link navegável. Aplica a cor semântica `text(link)`, remove o sublinhado padrão, e restaura o sublinhado no hover. No estado `:visited` usa `text(link-visited)`. Foco gerenciado via `@include focus-ring(primary)`.
+Use `lui-link` para navegação entre páginas, seções ou recursos externos. É adequado para links inline em texto corrido, CTAs textuais e qualquer situação onde a ação principal é navegar — diferente do `lui-button`, que representa ações que modificam estado ou disparam operações.
+
+Aplica a cor semântica `text(link)`, remove o sublinhado padrão e o restaura no hover. No estado `:visited` usa `text(link-visited)`. O foco é gerenciado via `@include focus-ring(primary)`, garantindo conformidade com WCAG 2.1 AA.
 
 <Canvas of={LinkStories.Default} />
 <Controls of={LinkStories.Default} />
 
-## Em parágrafo
+## Tamanhos
 
-Links geralmente aparecem inline dentro de blocos de texto. Use a tag `<a class="link">` diretamente para embutir um link em conteúdo corrido.
+Use `size` para controlar o tamanho do link. Os valores seguem a mesma escala do `lui-body`: `lg`, `md` e `sm`. Sem `size`, o link herda o `font-size` do contexto.
+
+<Canvas of={LinkStories.Sizes} />
+
+## Nova aba
+
+Use `target="_blank"` para abrir o link em uma nova aba. O atributo `rel` é automaticamente definido como `noopener noreferrer` neste caso, por segurança.
+
+<Canvas of={LinkStories.OpenInNewTab} />
+
+## Link externo
+
+Use o atributo booleano `external` para exibir um ícone indicativo de link externo ao lado do texto. Ao aplicá-lo, `target="_blank"` e `rel="noopener noreferrer"` são definidos automaticamente — não é necessário declará-los.
+
+<Canvas of={LinkStories.ExternalLink} />
+
+<Canvas of={LinkStories.ExternalInParagraph} />
+
+## Download
+
+Use `download` para que o navegador baixe o arquivo ao invés de navegar para ele. O valor do atributo define o nome sugerido para o arquivo baixado.
+
+<Canvas of={LinkStories.Download} />
+
+## Desabilitado
+
+Use `disabled` para impedir a navegação. O `href` é removido, `aria-disabled="true"` é adicionado e o elemento permanece focável via teclado (`tabindex="0"`).
+
+<Canvas of={LinkStories.Disabled} />
+
+## Rastreamento de visita
+
+Por padrão, o estilo `:visited` não é aplicado — evitando que o histórico de navegação do usuário altere a aparência do link sem intenção explícita. Use `track-visited` para habilitar a mudança de cor após o link ter sido visitado.
+
+Isso é útil em contextos como listas de artigos, resultados de busca ou menus de navegação, onde sinalizar visualmente o que já foi acessado melhora a orientação do usuário.
+
+<Canvas of={LinkStories.TrackVisited} />
+
+## Em parágrafo
 
 <Canvas of={LinkStories.InParagraph} />
 
-## Em slot
+## Via slot
 
 <Canvas of={LinkStories.WithSlot} />
 
-## Em label
+## Via label
 
 <Canvas of={LinkStories.WithLabel} />
 
 ## Com aria-label
 
-Quando o texto do link não descreve o destino com clareza (ex.: "saiba mais", "clique aqui"), forneça um `aria-label` descritivo para leitores de tela.
+Use `aria-label` quando o texto visível do link não descreve o destino com clareza para tecnologias assistivas. Casos comuns:
+
+- Textos genéricos como "saiba mais", "clique aqui" ou "leia mais" que só fazem sentido com o contexto visual ao redor
+- Links com apenas ícone ou imagem como conteúdo, sem texto legível
+- Múltiplos links com o mesmo texto em uma mesma página, mas com destinos diferentes
+
+O valor deve descrever o destino ou a ação, não repetir o texto visível. Prefira "Leia mais sobre acessibilidade" a "Leia mais".
 
 <Canvas of={LinkStories.WithAriaLabel} />
 
@@ -41,7 +87,23 @@ A estilização de link está disponível diretamente via classe CSS `.link` em 
 ### Web Component
 
 ```html
+<!-- Link padrão -->
 <lui-link label="Saiba mais" href="/sobre"></lui-link>
+
+<!-- Abrir em nova aba (rel adicionado automaticamente) -->
+<lui-link href="https://example.com" target="_blank">
+  Documentação
+</lui-link>
+
+<!-- Link externo com ícone -->
+<lui-link href="https://example.com" target="_blank" external>
+  Documentação externa
+</lui-link>
+
+<!-- Download -->
+<lui-link href="/assets/guia.pdf" download="guia-design-system.pdf">
+  Baixar guia
+</lui-link>
 
 <!-- Com aria-label personalizado -->
 <lui-link
@@ -49,6 +111,9 @@ A estilização de link está disponível diretamente via classe CSS `.link` em 
   href="/acessibilidade"
   aria-label="Leia mais sobre acessibilidade"
 ></lui-link>
+
+<!-- Desabilitado -->
+<lui-link href="/sobre" disabled>Link desabilitado</lui-link>
 ```
 
 ### Classe CSS
@@ -60,3 +125,20 @@ A estilização de link está disponível diretamente via classe CSS `.link` em 
   <a class="link" href="/termos">política de privacidade</a>.
 </p>
 ```
+
+## Atributos
+
+| Atributo         | Tipo      | Default  | Descrição |
+|------------------|-----------|----------|-----------|
+| `href`           | `string`  | `#`      | URL de destino |
+| `label`          | `string`  | —        | Texto do link (alternativa ao slot) |
+| `size`           | `string`  | —        | Tamanho do texto: `lg`, `md`, `sm`. Herda o `font-size` do contexto quando omitido |
+| `target`         | `string`  | `_self`  | Contexto de abertura (`_self`, `_blank`, `_parent`, `_top`) |
+| `rel`            | `string`  | —        | Relação do link. Quando `target="_blank"`, assume `noopener noreferrer` automaticamente |
+| `download`       | `string`  | —        | Nome sugerido do arquivo ao baixar |
+| `hreflang`       | `string`  | —        | Idioma do documento de destino |
+| `referrerpolicy` | `string`  | —        | Política de referrer enviada na requisição |
+| `external`       | `boolean` | `false`  | Exibe ícone de link externo ao lado do texto. Implica `target="_blank"` e `rel="noopener noreferrer"` automaticamente |
+| `visited`        | `boolean` | `false`  | Habilita o estilo `:visited` após o link ser clicado |
+| `disabled`       | `boolean` | `false`  | Desabilita a navegação: remove `href`, adiciona `aria-disabled="true"` e mantém o elemento focável |
+| `aria-label`     | `string`  | —        | Label acessível para leitores de tela |

--- a/packages/lets-ui-components/src/components/link/Link.stories.js
+++ b/packages/lets-ui-components/src/components/link/Link.stories.js
@@ -5,28 +5,172 @@ import '../../index.js';
 export default {
   title: 'Navigation/Link',
   argTypes: {
-    label: { control: 'text' },
-    href: { control: 'text' },
-    ariaLabel: { control: 'text' },
+    label: {
+      control: 'text',
+    },
+    href: {
+      control: 'text',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['', 'lg', 'md', 'sm'],
+      table: { defaultValue: { summary: 'lg' } },
+    },
+    target: {
+      control: { type: 'select' },
+      options: ['_self', '_blank', '_parent', '_top'],
+      table: { defaultValue: { summary: '_self' } },
+    },
+    rel: {
+      control: 'text',
+      table: {
+        defaultValue: {
+          summary: 'auto "noopener noreferrer" se target="_blank"',
+        },
+      },
+    },
+    download: {
+      control: 'text',
+    },
+    hreflang: {
+      control: 'text',
+    },
+    referrerpolicy: {
+      control: { type: 'select' },
+      options: [
+        '',
+        'no-referrer',
+        'no-referrer-when-downgrade',
+        'origin',
+        'origin-when-cross-origin',
+        'same-origin',
+        'strict-origin',
+        'strict-origin-when-cross-origin',
+        'unsafe-url',
+      ],
+    },
+    external: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    visited: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    ariaLabel: {
+      control: 'text',
+    },
   },
 };
 
-const Template = ({ label, href, ariaLabel }) => `
-  <lui-link
-    href="${href}"
-    ${ariaLabel ? `aria-label="${ariaLabel}"` : ''}
-  >
-    ${label}
-  </lui-link>
-`;
+const Template = ({
+  label,
+  href,
+  size,
+  target,
+  rel,
+  download,
+  hreflang,
+  referrerpolicy,
+  external,
+  disabled,
+  visited,
+  ariaLabel,
+}) => {
+  const attrs = [
+    `href="${href}"`,
+    size && `size="${size}"`,
+    target && `target="${target}"`,
+    rel && `rel="${rel}"`,
+    download && `download="${download}"`,
+    hreflang && `hreflang="${hreflang}"`,
+    referrerpolicy && `referrerpolicy="${referrerpolicy}"`,
+    external && 'external',
+    disabled && 'disabled',
+    visited && 'visited',
+    ariaLabel && `aria-label="${ariaLabel}"`,
+  ]
+    .filter(Boolean)
+    .join('\n    ');
+
+  return `<lui-link\n    ${attrs}\n  >\n    ${label}\n  </lui-link>`;
+};
 
 export const Default = Template.bind({});
 Default.args = {
   label: 'Saiba mais',
+  ariaLabel: '',
   href: '#',
-  ariaLabel: 'Saiba mais informações sobre o design system',
+  target: '',
+  size: '',
+  external: false,
+  visited: false,
+  rel: '',
+  download: '',
+  hreflang: '',
+  referrerpolicy: '',
+  disabled: false,
 };
 Default.storyName = 'Default';
+
+export const Sizes = () => `
+  <div style="display: flex; flex-direction: column; gap: 12px;">
+    <lui-link href="#" size="lg">Large</lui-link>
+    <lui-link href="#" size="md">Medium</lui-link>
+    <lui-link href="#" size="sm">Small</lui-link>
+  </div>
+`;
+Sizes.storyName = 'Tamanhos';
+
+export const OpenInNewTab = () => `
+  <lui-link href="https://example.com" target="_blank">
+    Abrir em nova aba
+  </lui-link>
+`;
+OpenInNewTab.storyName = 'Nova aba (_blank)';
+
+export const ExternalLink = () => `
+  <lui-link href="https://example.com" target="_blank" external>
+    Documentação externa
+  </lui-link>
+`;
+ExternalLink.storyName = 'Link externo';
+
+export const ExternalInParagraph = () => `
+  <lui-body variant="lg">
+    Para entender mais sobre design systems, leia
+    <lui-link href="https://www.casadocodigo.com.br/products/livro-design-system" target="_blank" external>
+      Design System além do layout
+    </lui-link>
+    de Mateus Villain.
+  </lui-body>
+`;
+ExternalInParagraph.storyName = 'Link externo em parágrafo';
+
+export const Download = () => `
+  <lui-link href="/assets/guia.pdf" download="guia-design-system.pdf">
+    Baixar guia
+  </lui-link>
+`;
+Download.storyName = 'Download';
+
+export const Disabled = () => `
+  <div style="display: flex; gap: 16px;">
+    <lui-link href="/sobre" disabled>Link desabilitado</lui-link>
+    <lui-link href="/sobre" disabled external>Link externo desabilitado</lui-link>
+  </div>
+`;
+Disabled.storyName = 'Desabilitado';
+
+export const TrackVisited = () => `
+  <p style="font-family: sans-serif; font-size: 14px; margin-bottom: 8px; color: #666;">Clique no link abaixo e volte para ver o estado :visited</p>
+  <lui-link href="https://example.com" target="_blank" visited>Link com rastreamento de visita</lui-link>
+`;
+TrackVisited.storyName = 'Com rastreamento de visita';
 
 export const InParagraph = () => `
   <lui-body variant="lg">
@@ -36,20 +180,14 @@ export const InParagraph = () => `
 InParagraph.storyName = 'Em parágrafo';
 
 export const WithSlot = () => `
-  <lui-link
-    href="#"
-  >
-    Acesse sua <strong>conta</strong>
+  <lui-link href="#">
+    <lui-button variant="primary" size="lg" label="Começar agora"></lui-button>
   </lui-link>
 `;
-
 WithSlot.storyName = 'Via slot';
 
 export const WithLabel = () => `
-  <lui-link
-    label="Esqueci minha senha"
-    href="#"
-  ></lui-link>
+  <lui-link label="Esqueci minha senha" href="#"></lui-link>
 `;
 WithLabel.storyName = 'Via label';
 

--- a/packages/lets-ui-components/src/components/link/link.ts
+++ b/packages/lets-ui-components/src/components/link/link.ts
@@ -1,21 +1,65 @@
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, html, unsafeCSS, svg } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './link.scss?inline';
+
+const externalIcon = svg`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="3 3 18 18" aria-hidden="true" class="link__external-icon">
+  <path fill="currentColor" d="M11.25 4.5a.75.75 0 0 1 0 1.5H6v12h12v-5.25a.75.75 0 0 1 1.5 0V18a1.5 1.5 0 0 1-1.5 1.5H6A1.5 1.5 0 0 1 4.5 18V6A1.5 1.5 0 0 1 6 4.5h5.25Zm9-1.5a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0V5.56l-6.22 6.22a.75.75 0 1 1-1.06-1.06l6.22-6.22h-4.19a.75.75 0 0 1 0-1.5h6Z"/>
+</svg>`;
 
 export class LuiLink extends LitElement {
   static styles = unsafeCSS(styles);
 
   @property() label = '';
   @property() href = '#';
+  @property() size = '';
+  @property() target = '_self';
+  @property() rel = '';
+  @property() download = '';
+  @property() hreflang = '';
+  @property() referrerpolicy = '';
+  @property({ type: Boolean }) external = false;
+  @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean }) visited = false;
   @property({ attribute: 'aria-label' }) ariaLabel = '';
+
+  private get _target(): string {
+    return this.external ? '_blank' : this.target;
+  }
+
+  private get _rel(): string | undefined {
+    if (this.rel) return this.rel;
+    if (this._target === '_blank') return 'noopener noreferrer';
+    return undefined;
+  }
+
+  private get _classes(): string {
+    return [
+      'link',
+      this.size &&
+        ['lg', 'md', 'sm'].includes(this.size) &&
+        `link--${this.size}`,
+      this.visited && 'link--visited',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
 
   render() {
     return html`<a
-      class="link"
-      href="${this.href}"
+      class="${this._classes}"
+      href="${ifDefined(this.disabled ? undefined : this.href)}"
+      target="${ifDefined(
+        this.disabled ? undefined : this._target || undefined
+      )}"
+      rel="${ifDefined(this.disabled ? undefined : this._rel)}"
+      download="${ifDefined(this.download || undefined)}"
+      hreflang="${ifDefined(this.hreflang || undefined)}"
+      referrerpolicy="${ifDefined(this.referrerpolicy || undefined)}"
+      tabindex="${ifDefined(this.disabled ? '0' : undefined)}"
+      aria-disabled="${ifDefined(this.disabled ? 'true' : undefined)}"
       aria-label="${ifDefined(this.ariaLabel || undefined)}"
-      ><slot>${this.label}</slot></a
+      ><slot>${this.label}</slot>${this.external ? externalIcon : ''}</a
     >`;
   }
 }

--- a/packages/styles/src/components/_link.scss
+++ b/packages/styles/src/components/_link.scss
@@ -5,13 +5,38 @@ a.link {
   color: text(link);
   text-decoration: none;
 
-  &:hover {
+  &:not([aria-disabled='true']):hover {
     text-decoration: underline;
   }
 
-  &:visited {
+  &.link--visited:visited {
     color: text(link-visited);
   }
 
   @include focus-ring(primary);
+
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+    opacity: opacity(disabled);
+  }
+
+  &.link--lg {
+    @include font-scale(body--lg);
+  }
+
+  &.link--md {
+    @include font-scale(body--md);
+  }
+
+  &.link--sm {
+    @include font-scale(body--sm);
+  }
+
+  .link__external-icon {
+    display: inline-block;
+    height: 1em;
+    width: auto;
+    margin-inline-start: 0.25em;
+    vertical-align: -0.125em;
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `target`, `rel` (auto `noopener noreferrer` on `_blank`), `download`, `hreflang`, and `referrerpolicy` props for full anchor attribute coverage
- Adds `external` boolean — renders an inline SVG icon and implies `target="_blank"` + `rel="noopener noreferrer"` automatically
- Adds `size` prop (`lg`, `md`, `sm`) following the same typographic scale as `lui-body`; omitted inherits `font-size` from context
- Adds `disabled` boolean — removes `href`, sets `aria-disabled="true"`, and keeps the element keyboard-focusable
- Adds `visited` boolean — opt-in `:visited` styling, off by default to avoid unintentional exposure of browsing history
- Updates stories, MDX docs, and CHANGELOG

## Test plan

- [ ] Verify that `target="_blank"` without an explicit `rel` automatically adds `noopener noreferrer`
- [ ] Verify that `external` implies `target="_blank"` and `rel="noopener noreferrer"` without manual declaration
- [ ] Verify that `disabled` removes `href`, blocks navigation, and keeps keyboard focus
- [ ] Verify that `aria-disabled="true"` is rendered correctly (not `aria-disabled=""`)
- [ ] Verify that `cursor: not-allowed` appears in the `disabled` state
- [ ] Verify that the external icon matches the surrounding text size
- [ ] Verify that `size` inherits `font-size` from context when omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)