### PR TITLE
feat(forms): add ElementInternals form integration to all form components

### DIFF
--- a/.changeset/sweet-groups-guess.md
+++ b/.changeset/sweet-groups-guess.md
@@ -1,0 +1,20 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+- New `type` prop on `lui-button` (`button` | `submit` | `reset`, default `button`) for native form semantics.
+- New `block` boolean prop on `lui-button` — stretches the button to full container width.
+- New `loading` boolean prop on `lui-button` — shows an animated spinner, sets `aria-busy="true"`, and blocks interaction with `cursor: wait`.
+- New `loading-text` prop on `lui-button` — label displayed while `loading` is active; falls back to `label` when omitted.
+- New `prefix` and `suffix` named slots on `lui-button` for leading/trailing icons; default slot falls back to the `label` attribute.
+- New `autofocus` boolean prop on `lui-button`.
+- Form integration (`ElementInternals`) for `lui-button` — adds `name`, `value`, and `form` props; submit and reset are handled via a click listener so the inner `<button type="button">` never accidentally submits; `formDisabledCallback` keeps `disabled` in sync with the owning `<form>`.
+- Form integration for `lui-checkbox` — adds `name`, `value`, `form`, and `required` props; validity is managed via `ElementInternals`; new `error` and `error-text` props render an inline error message below the control; slot support replaces the hardcoded `<span>` label.
+- Form integration for `lui-input` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration for `lui-radio` — adds `ElementInternals` support; sibling deselection is now coordinated through the enclosing `lui-radio-group`; slot support replaces the hardcoded label `<span>`.
+- New `lui-radio-group` component — wraps `lui-radio` elements with a shared `name`; manages `label`, `size`, `hint`, `required`, `disabled`, `error`, and `error-text`; form value and validity are handled via `ElementInternals`.
+- Form integration for `lui-select` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration for `lui-switch` — adds `name`, `value`, `form`, and `required` props; new `error` and `error-text` props render an inline error message; slot support replaces the hardcoded label `<span>`.
+- Form integration for `lui-textarea` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@
 - New `loading-text` prop on `lui-button` — label displayed while `loading` is active; falls back to `label` when omitted.
 - New `prefix` and `suffix` named slots on `lui-button` for leading/trailing icons; default slot falls back to the `label` attribute.
 - New `autofocus` boolean prop on `lui-button`.
-- Form integration (`ElementInternals`) for `lui-button` — adds `name`, `value`, and `form` props; submit and reset are handled via a click listener so the inner `<button type="button">` never accidentally submits; `formDisabledCallback` keeps `disabled` in sync with the owning `<form>`.
-- Form integration for `lui-checkbox` — adds `name`, `value`, `form`, and `required` props; validity is managed via `ElementInternals`; new `error` and `error-text` props render an inline error message below the control; slot support replaces the hardcoded `<span>` label.
-- Form integration for `lui-input` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration (`ElementInternals`) for `lui-button` — adds `name` and `value` props; submit and reset are handled via a click listener so the inner `<button type="button">` never accidentally submits; `formDisabledCallback` keeps `disabled` in sync with the owning `<form>`.
+- Form integration for `lui-checkbox` — adds `name`, `value`, and `required` props; validity is managed via `ElementInternals`; new `error` and `error-text` props render an inline error message below the control; slot support replaces the hardcoded `<span>` label.
+- Form integration for `lui-input` — adds `name` and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
 - Form integration for `lui-radio` — adds `ElementInternals` support; sibling deselection is now coordinated through the enclosing `lui-radio-group`; slot support replaces the hardcoded label `<span>`.
 - New `lui-radio-group` component — wraps `lui-radio` elements with a shared `name`; manages `label`, `size`, `hint`, `required`, `disabled`, `error`, and `error-text`; form value and validity are handled via `ElementInternals`.
-- Form integration for `lui-select` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
-- Form integration for `lui-switch` — adds `name`, `value`, `form`, and `required` props; new `error` and `error-text` props render an inline error message; slot support replaces the hardcoded label `<span>`.
-- Form integration for `lui-textarea` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration for `lui-select` — adds `name` and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration for `lui-switch` — adds `name`, `value`, and `required` props; new `error` and `error-text` props render an inline error message; slot support replaces the hardcoded label `<span>`.
+- Form integration for `lui-textarea` — adds `name` and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@
 - New `size` prop on `lui-link` with `lg`, `md`, and `sm` values following the same typographic scale as `lui-body`; omitting it inherits `font-size` from context.
 - New `disabled` boolean prop on `lui-link` — removes `href`, sets `aria-disabled="true"`, and keeps the element focusable via `tabindex="0"`.
 - New `visited` boolean prop on `lui-link` — opt-in `:visited` styling, off by default to avoid unintentional exposure of browsing history.
+- New `type` prop on `lui-button` (`button` | `submit` | `reset`, default `button`) for native form semantics.
+- New `block` boolean prop on `lui-button` — stretches the button to full container width.
+- New `loading` boolean prop on `lui-button` — shows an animated spinner, sets `aria-busy="true"`, and blocks interaction with `cursor: wait`.
+- New `loading-text` prop on `lui-button` — label displayed while `loading` is active; falls back to `label` when omitted.
+- New `prefix` and `suffix` named slots on `lui-button` for leading/trailing icons; default slot falls back to the `label` attribute.
+- New `autofocus` boolean prop on `lui-button`.
+- Form integration (`ElementInternals`) for `lui-button` — adds `name`, `value`, and `form` props; submit and reset are handled via a click listener so the inner `<button type="button">` never accidentally submits; `formDisabledCallback` keeps `disabled` in sync with the owning `<form>`.
+- Form integration for `lui-checkbox` — adds `name`, `value`, `form`, and `required` props; validity is managed via `ElementInternals`; new `error` and `error-text` props render an inline error message below the control; slot support replaces the hardcoded `<span>` label.
+- Form integration for `lui-input` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration for `lui-radio` — adds `ElementInternals` support; sibling deselection is now coordinated through the enclosing `lui-radio-group`; slot support replaces the hardcoded label `<span>`.
+- New `lui-radio-group` component — wraps `lui-radio` elements with a shared `name`; manages `label`, `size`, `hint`, `required`, `disabled`, `error`, and `error-text`; form value and validity are handled via `ElementInternals`.
+- Form integration for `lui-select` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
+- Form integration for `lui-switch` — adds `name`, `value`, `form`, and `required` props; new `error` and `error-text` props render an inline error message; slot support replaces the hardcoded label `<span>`.
+- Form integration for `lui-textarea` — adds `name`, `form`, and `required` props; `formDisabledCallback` and `formResetCallback` keep state consistent with the owning `<form>`.
 
 ### Fixed
 

--- a/packages/lets-ui-components/src/components/button/Button.docs.mdx
+++ b/packages/lets-ui-components/src/components/button/Button.docs.mdx
@@ -80,6 +80,15 @@ O atributo `loading-text` substitui o label exibido enquanto `loading` estiver a
 
 <Canvas of={ButtonStories.AllVariantsLoading} />
 
+## Integração com formulários
+
+`type="submit"` e `type="reset"` funcionam nativamente com qualquer `<form>` pai.
+Dois botões de submit com `name` e `value` distintos permitem identificar qual ação foi escolhida
+nos dados submetidos. O atributo `form` permite associar o botão a um form pelo ID,
+mesmo que esteja fora do elemento `<form>` no DOM.
+
+<Canvas of={ButtonStories.FormIntegration} />
+
 ## Autofocus
 
 Use `autofocus` para mover o foco do teclado automaticamente para o botão quando o contexto é renderizado.
@@ -100,6 +109,9 @@ como modais, drawers e alertas de confirmação.
 | `variant`      | `string`  | `'primary'` | Estilo visual: `primary`, `secondary`, `neutral`, `danger`, `success` |
 | `size`         | `string`  | `'lg'`      | Tamanho: `lg`, `md`                                                   |
 | `type`         | `string`  | `'button'`  | Tipo HTML: `button`, `submit`, `reset`                                |
+| `name`         | `string`  | `''`        | Nome submetido com o form ao usar `type="submit"`                     |
+| `value`        | `string`  | `''`        | Valor submetido junto ao `name`; incluído apenas quando este botão dispara o submit |
+| `form`         | `string`  | `''`        | ID do `<form>` associado; permite usar o botão fora do elemento form  |
 | `disabled`     | `boolean` | `false`     | Desabilita o botão e previne interações                               |
 | `autofocus`    | `boolean` | `false`     | Move o foco para o botão automaticamente ao renderizar o contexto     |
 | `block`        | `boolean` | `false`     | Torna o botão full-width dentro do seu container                      |

--- a/packages/lets-ui-components/src/components/button/Button.stories.js
+++ b/packages/lets-ui-components/src/components/button/Button.stories.js
@@ -35,6 +35,18 @@ export default {
       options: ['button', 'submit', 'reset'],
       table: { defaultValue: { summary: 'button' } },
     },
+    name: {
+      control: 'text',
+      table: { defaultValue: { summary: "''" } },
+    },
+    value: {
+      control: 'text',
+      table: { defaultValue: { summary: "''" } },
+    },
+    form: {
+      control: 'text',
+      table: { defaultValue: { summary: "''" } },
+    },
     autofocus: {
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
@@ -53,6 +65,9 @@ const Template = ({
   variant,
   size,
   type,
+  name,
+  value,
+  form,
   autofocus,
   disabled,
   block,
@@ -64,6 +79,9 @@ const Template = ({
     `variant="${variant}"`,
     `size="${size}"`,
     type !== 'button' && `type="${type}"`,
+    name && `name="${name}"`,
+    value && `value="${value}"`,
+    form && `form="${form}"`,
     autofocus && 'autofocus',
     disabled && 'disabled',
     block && 'block',
@@ -84,6 +102,9 @@ Button.args = {
   variant: 'primary',
   size: 'lg',
   type: 'button',
+  name: '',
+  value: '',
+  form: '',
   block: false,
   autofocus: false,
   disabled: false,
@@ -169,6 +190,59 @@ Autofocus.parameters = {
     description: {
       story:
         'O botão com `autofocus` recebe foco automaticamente quando o contexto é carregado. Neste preview, o botão "Confirmar" já está focado ao abrir a story.',
+    },
+  },
+};
+
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 360px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="demo-form" style="display: flex; flex-direction: column; gap: 16px;">
+      <div style="display: flex; flex-direction: column; gap: 6px;">
+        <label for="demo-name" style="font-size: 14px; font-weight: 500;">Nome</label>
+        <input id="demo-name" name="name" type="text" required placeholder="Digite seu nome"
+          style="padding: 8px 12px; border: 1px solid #ccc; border-radius: 6px; font-size: 14px; font-family: inherit;">
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 6px;">
+        <label for="demo-email" style="font-size: 14px; font-weight: 500;">E-mail</label>
+        <input id="demo-email" name="email" type="email" required placeholder="seu@email.com"
+          style="padding: 8px 12px; border: 1px solid #ccc; border-radius: 6px; font-size: 14px; font-family: inherit;">
+      </div>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary" size="md">Limpar</lui-button>
+        <lui-button type="submit" variant="secondary" size="md" name="action" value="draft">Salvar rascunho</lui-button>
+        <lui-button type="submit" variant="primary" size="md" name="action" value="publish">Publicar</lui-button>
+      </div>
+    </form>
+    <p id="demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
+
+  const form = container.querySelector('#demo-form');
+  const feedback = container.querySelector('#demo-feedback');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    const action = data.get('action');
+    const label = action === 'publish' ? 'Publicado' : 'Rascunho salvo';
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ ${label}: ${data.get('name')} <${data.get('email')}>`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  docs: {
+    description: {
+      story:
+        'Demonstração completa da integração com formulários. `type="reset"` limpa os campos nativamente. Dois botões `type="submit"` com `name="action"` e `value` distintos permitem identificar qual ação foi escolhida nos dados submetidos.',
     },
   },
 };

--- a/packages/lets-ui-components/src/components/button/button.ts
+++ b/packages/lets-ui-components/src/components/button/button.ts
@@ -9,10 +9,21 @@ const spinnerIcon = svg`<svg xmlns="http://www.w3.org/2000/svg" fill="none" view
 
 export class LuiButton extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
+
+  constructor() {
+    super();
+    this._internals = this.attachInternals();
+  }
 
   @property() variant = 'primary';
   @property({ reflect: true }) size = 'lg';
   @property() type: 'button' | 'submit' | 'reset' = 'button';
+  @property() name = '';
+  @property() value = '';
+  @property() form = '';
   @property({ type: Boolean }) autofocus = false;
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) block = false;
@@ -20,6 +31,10 @@ export class LuiButton extends LitElement {
   @property({ attribute: 'loading-text' }) loadingText = '';
   @property() label = '';
   @property({ attribute: 'aria-label' }) ariaLabel = '';
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
 
   get _size(): 'lg' | 'md' {
     return this.size === 'md' ? 'md' : 'lg';
@@ -36,6 +51,18 @@ export class LuiButton extends LitElement {
       .join(' ');
   }
 
+  private _handleClick = () => {
+    if (this.loading) return;
+    const form = this._internals.form ?? this.closest('form');
+    if (this.type === 'submit') {
+      if (this.name) this._internals.setFormValue(this.value);
+      form?.requestSubmit();
+      if (this.name) this._internals.setFormValue(null);
+    } else if (this.type === 'reset') {
+      form?.reset();
+    }
+  };
+
   render() {
     const displayLabel =
       this.loading && this.loadingText ? this.loadingText : this.label;
@@ -44,12 +71,13 @@ export class LuiButton extends LitElement {
     return html`
       <button
         class="${this._classes}"
-        type="${this.type}"
+        type="button"
         ?autofocus="${this.autofocus}"
         aria-label="${ifDefined(this.ariaLabel || displayLabel || undefined)}"
         ?disabled="${this.disabled}"
         aria-disabled="${isDisabled ? 'true' : 'false'}"
         aria-busy="${ifDefined(this.loading ? 'true' : undefined)}"
+        @click="${this._handleClick}"
       >
         ${this.loading
           ? html`${spinnerIcon}${displayLabel}`

--- a/packages/lets-ui-components/src/components/button/button.ts
+++ b/packages/lets-ui-components/src/components/button/button.ts
@@ -23,7 +23,6 @@ export class LuiButton extends LitElement {
   @property() type: 'button' | 'submit' | 'reset' = 'button';
   @property() name = '';
   @property() value = '';
-  @property() form = '';
   @property({ type: Boolean }) autofocus = false;
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) block = false;

--- a/packages/lets-ui-components/src/components/checkbox/Checkbox.docs.mdx
+++ b/packages/lets-ui-components/src/components/checkbox/Checkbox.docs.mdx
@@ -1,15 +1,53 @@
-import { Meta, Canvas, Controls, ArgTypes } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as CheckboxStories from './Checkbox.stories';
 
 <Meta of={CheckboxStories} />
 
 # Checkbox
 
+Elemento de seleção binária. O conteúdo da label é projetado via slot — o atributo `label` serve como fallback para texto simples.
+
 <Canvas of={CheckboxStories.Checkbox} />
 <Controls of={CheckboxStories.Checkbox} />
 
+## Label (atributo)
+
+O atributo `label` renderiza o texto como conteúdo padrão do slot. Útil para casos simples ou geração programática de HTML.
+
+<Canvas of={CheckboxStories.LabelAttribute} />
+
+## Checked
+
+<Canvas of={CheckboxStories.Checked} />
+
 ## Small
+
 <Canvas of={CheckboxStories.Small} />
 
 ## Disabled
+
 <Canvas of={CheckboxStories.Disabled} />
+
+## Integração com formulários
+
+O `lui-checkbox` é form-associated. Use `name` para identificar o campo no `FormData` e `value` para definir o que é submetido quando marcado (padrão `"on"`, igual ao nativo).
+
+### Required
+
+Com `required`, o form não submete enquanto o checkbox não estiver marcado.
+
+<Canvas of={CheckboxStories.Required} />
+
+### Form Integration
+
+<Canvas of={CheckboxStories.FormIntegration} />
+
+## Atributos de formulário
+
+| Atributo   | Tipo      | Padrão | Descrição                                                                       |
+| ---------- | --------- | ------ | ------------------------------------------------------------------------------- |
+| `label`    | `string`  | `''`   | Conteúdo padrão do slot; ignorado quando o slot é projetado                     |
+| `name`     | `string`  | `''`   | Nome do campo nos dados submetidos                                              |
+| `value`    | `string`  | `'on'` | Valor submetido quando marcado; omitido quando desmarcado                       |
+| `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o checkbox fora do elemento form         |
+| `required` | `boolean` | `false`| Bloqueia a submissão quando o checkbox não está marcado                         |

--- a/packages/lets-ui-components/src/components/checkbox/Checkbox.stories.js
+++ b/packages/lets-ui-components/src/components/checkbox/Checkbox.stories.js
@@ -6,43 +6,147 @@ export default {
   title: 'Form and options/Checkbox',
   argTypes: {
     label: { control: 'text' },
-    checked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    name: { control: 'text' },
+    value: { control: 'text', table: { defaultValue: { summary: 'on' } } },
+    form: { control: 'text' },
+    checked: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     size: {
       control: { type: 'select' },
       options: ['lg', 'md'],
+      table: { defaultValue: { summary: 'lg' } },
     },
   },
 };
 
-const Template = ({ label, checked, disabled, size }) =>
-  `<lui-checkbox
-    label="${label ?? ''}"
-    size="${size}"
-    ${checked ? 'checked' : ''}
-    ${disabled ? 'disabled' : ''}
-  ></lui-checkbox>`;
+const Template = ({
+  label,
+  name,
+  value,
+  form,
+  checked,
+  disabled,
+  required,
+  size,
+}) => {
+  const attrs = [
+    `size="${size ?? 'lg'}"`,
+    name ? `name="${name}"` : '',
+    value && value !== 'on' ? `value="${value}"` : '',
+    form ? `form="${form}"` : '',
+    checked ? 'checked' : '',
+    disabled ? 'disabled' : '',
+    required ? 'required' : '',
+  ]
+    .filter(Boolean)
+    .join('\n  ');
+
+  return `<lui-checkbox\n  ${attrs}\n>\n  ${label ?? ''}\n</lui-checkbox>`;
+};
 
 export const Checkbox = Template.bind({});
 Checkbox.args = {
   label: 'Checkbox label',
+  name: '',
+  value: 'on',
+  form: '',
   checked: false,
   disabled: false,
+  required: false,
   size: 'lg',
 };
 
-export const Small = Template.bind({});
-Small.args = {
-  label: 'Label',
-  checked: false,
-  disabled: false,
-  size: 'md',
+export const LabelAttribute = () =>
+  `<lui-checkbox label="Opção via atributo" size="lg"></lui-checkbox>`;
+LabelAttribute.storyName = 'Label (atributo)';
+LabelAttribute.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'Fallback para texto simples: o atributo `label` é renderizado como conteúdo padrão do slot quando nenhum conteúdo é projetado.',
+    },
+  },
 };
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  label: 'Label',
-  checked: true,
-  disabled: true,
-  size: 'lg',
+export const Checked = () =>
+  `<lui-checkbox checked size="lg">Opção selecionada</lui-checkbox>`;
+
+export const Small = () => `<lui-checkbox size="md">Label</lui-checkbox>`;
+
+export const Disabled = () =>
+  `<lui-checkbox checked disabled size="lg">Desabilitado</lui-checkbox>`;
+
+export const Required = () => `
+  <form id="checkbox-required-form" style="display: flex; flex-direction: column; gap: 12px; max-width: 320px;">
+    <lui-checkbox name="terms" value="accepted" required size="lg">
+      Li e aceito os termos de uso
+    </lui-checkbox>
+    <lui-button type="submit" variant="primary" size="md">Continuar</lui-button>
+  </form>
+`;
+Required.parameters = {
+  docs: {
+    description: {
+      story:
+        'Com `required`, o form não submete enquanto o checkbox não estiver marcado.',
+    },
+  },
+};
+
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 360px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="checkbox-demo-form" style="display: flex; flex-direction: column; gap: 16px;">
+      <lui-checkbox name="newsletter" value="subscribed" size="lg">
+        Quero receber novidades por e-mail
+      </lui-checkbox>
+      <lui-checkbox name="terms" value="accepted" required size="lg">
+        Li e aceito os termos de uso
+      </lui-checkbox>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary" size="md">Limpar</lui-button>
+        <lui-button type="submit" variant="primary" size="md">Cadastrar</lui-button>
+      </div>
+    </form>
+    <p id="checkbox-demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
+
+  const form = container.querySelector('#checkbox-demo-form');
+  const feedback = container.querySelector('#checkbox-demo-feedback');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    const newsletter = data.get('newsletter') ? 'sim' : 'não';
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ Cadastrado. Newsletter: ${newsletter}`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  docs: {
+    description: {
+      story:
+        'Quando marcado, submete `value` no `FormData` com a chave `name`. Quando desmarcado, o campo é omitido — comportamento idêntico ao `<input type="checkbox">` nativo. O campo `terms` é `required`.',
+    },
+  },
 };

--- a/packages/lets-ui-components/src/components/checkbox/checkbox.scss
+++ b/packages/lets-ui-components/src/components/checkbox/checkbox.scss
@@ -1,5 +1,5 @@
 @use 'packages/styles/src/components/checkbox' as *;
 
 :host {
-  display: inline-flex;
+  display: block;
 }

--- a/packages/lets-ui-components/src/components/checkbox/checkbox.ts
+++ b/packages/lets-ui-components/src/components/checkbox/checkbox.ts
@@ -1,21 +1,59 @@
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './checkbox.scss?inline';
 
 export class LuiCheckbox extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
 
   @property() label = '';
+  @property() name = '';
+  @property() value = 'on';
+  @property() form = '';
   @property({ type: Boolean }) checked = false;
   @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean }) required = false;
   @property() size = 'lg';
   @property({ attribute: 'aria-label' }) ariaLabel = '';
+  @property({ type: Boolean }) error = false;
+  @property({ attribute: 'error-text' }) errorText = 'Campo obrigatório.';
 
   private _baseId: string;
 
   constructor() {
     super();
     this._baseId = `lui-checkbox-${Math.random().toString(36).slice(2, 9)}`;
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._internals.setFormValue(this.checked ? this.value : null);
+    this.addEventListener('invalid', () => {
+      this.error = true;
+    });
+  }
+
+  protected firstUpdated() {
+    this._syncFormValue();
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('checked')) {
+      this._syncFormValue();
+    }
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this.checked = false;
+    this.error = false;
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {
@@ -27,27 +65,45 @@ export class LuiCheckbox extends LitElement {
       : 'lg';
   }
 
-  private _handleChange(e: Event) {
+  private _syncFormValue() {
+    this._internals.setFormValue(this.checked ? this.value : null);
+    if (this.required && !this.checked) {
+      this._internals.setValidity({ valueMissing: true }, 'Campo obrigatório.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  private _handleChange = (e: Event) => {
     const input = e.target as HTMLInputElement;
     this.checked = input.checked;
+    if (this.checked) this.error = false;
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
-  }
+  };
 
   render() {
     const ariaLabel = this.ariaLabel || this.label || 'Checkbox';
     return html`
-      <label class="checkbox checkbox--${this._size}">
-        <input
-          id="${this._baseId}-input"
-          type="checkbox"
-          aria-label="${ariaLabel}"
-          .checked="${this.checked}"
-          ?disabled="${this.disabled}"
-          ?aria-disabled="${this.disabled}"
-          @change="${this._handleChange}"
-        />
-        <span id="${this._baseId}-label">${this.label}</span>
-      </label>
+      <div class="checkbox-field${this.error ? ' checkbox-field--error' : ''}">
+        <label class="checkbox checkbox--${this._size}">
+          <input
+            id="${this._baseId}-input"
+            type="checkbox"
+            name="${ifDefined(this.name || undefined)}"
+            .value="${this.value}"
+            aria-label="${ariaLabel}"
+            .checked="${this.checked}"
+            ?disabled="${this.disabled}"
+            ?required="${this.required}"
+            ?aria-disabled="${this.disabled}"
+            @change="${this._handleChange}"
+          />
+          <slot>${this.label}</slot>
+        </label>
+        ${this.error && this.errorText
+          ? html`<p class="checkbox-field__message">${this.errorText}</p>`
+          : ''}
+      </div>
     `;
   }
 }

--- a/packages/lets-ui-components/src/components/checkbox/checkbox.ts
+++ b/packages/lets-ui-components/src/components/checkbox/checkbox.ts
@@ -12,7 +12,6 @@ export class LuiCheckbox extends LitElement {
   @property() label = '';
   @property() name = '';
   @property() value = 'on';
-  @property() form = '';
   @property({ type: Boolean }) checked = false;
   @property({ type: Boolean }) disabled = false;
   @property({ type: Boolean }) required = false;

--- a/packages/lets-ui-components/src/components/input/Input.docs.mdx
+++ b/packages/lets-ui-components/src/components/input/Input.docs.mdx
@@ -23,3 +23,30 @@ import * as InputStories from './Input.stories';
 ## Disabled
 
 <Canvas of={InputStories.Disabled} />
+
+## Integração com formulários
+
+O `lui-input` é um form-associated custom element — seus valores são capturados automaticamente
+pelo `FormData` do form pai através do atributo `name`.
+
+Use `form` para associar o input a um form por ID, mesmo que esteja fora do elemento `<form>` no DOM.
+
+### Required
+
+O atributo `required` bloqueia a submissão do form quando o campo está vazio.
+A validação é implementada via `ElementInternals.setValidity()`, mantendo o comportamento
+consistente com elementos nativos. A mensagem reportada é controlada pelo atributo `error-text`.
+
+<Canvas of={InputStories.Required} />
+
+### Form Integration
+
+<Canvas of={InputStories.FormIntegration} />
+
+## Atributos de formulário
+
+| Atributo   | Tipo      | Padrão | Descrição                                                                    |
+| ---------- | --------- | ------ | ---------------------------------------------------------------------------- |
+| `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`   |
+| `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o input fora do elemento form         |
+| `required` | `boolean` | `false`| Bloqueia a submissão quando o campo está vazio; valida via `ElementInternals`|

--- a/packages/lets-ui-components/src/components/input/Input.stories.js
+++ b/packages/lets-ui-components/src/components/input/Input.stories.js
@@ -8,29 +8,70 @@ export default {
     type: {
       control: { type: 'select' },
       options: ['text', 'password', 'number'],
+      table: { defaultValue: { summary: 'text' } },
     },
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    value: { control: 'text' },
+    label: {
+      control: 'text',
+    },
+    placeholder: {
+      control: 'text',
+    },
+    value: {
+      control: 'text',
+    },
     size: {
       control: { type: 'select' },
       options: ['lg', 'md', 'sm'],
+      table: { defaultValue: { summary: 'lg' } },
     },
-    optional: { control: 'boolean' },
-    optionalText: { control: 'text' },
-    maxlength: { control: 'number' },
-    hint: { control: 'text' },
-    error: { control: 'boolean' },
-    errorText: { control: 'text' },
-    prefix: { control: 'text' },
-    suffix: { control: 'text' },
-    disabled: { control: 'boolean' },
-    min: { control: 'number' },
-    max: { control: 'number' },
-    step: { control: 'number' },
-    forceState: {
-      control: { type: 'select' },
-      options: ['', 'hovered', 'focused'],
+    name: {
+      control: 'text',
+    },
+    form: {
+      control: 'text',
+    },
+    required: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    optional: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    optionalText: {
+      control: 'text',
+    },
+    maxlength: {
+      control: 'number',
+    },
+    hint: {
+      control: 'text',
+    },
+    error: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    errorText: {
+      control: 'text',
+    },
+    prefix: {
+      control: 'text',
+    },
+    suffix: {
+      control: 'text',
+    },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    min: {
+      control: 'number',
+    },
+    max: {
+      control: 'number',
+    },
+    step: {
+      control: 'number',
     },
   },
 };
@@ -41,20 +82,21 @@ const Template = ({
   placeholder,
   value,
   size,
+  name,
+  form,
+  required,
   optional,
   optionalText,
   maxlength,
   hint,
   error,
   errorText,
-  icon,
   prefix,
   suffix,
   disabled,
   min,
   max,
   step,
-  forceState,
 }) => {
   const attrs = [
     `type="${type ?? 'text'}"`,
@@ -62,6 +104,9 @@ const Template = ({
     `placeholder="${placeholder ?? ''}"`,
     `value="${value ?? ''}"`,
     `size="${size ?? 'lg'}"`,
+    name ? `name="${name}"` : '',
+    form ? `form="${form}"` : '',
+    required ? 'required' : '',
     optional ? 'optional' : '',
     optionalText ? `optional-text="${optionalText}"` : '',
     Number.isFinite(Number(maxlength))
@@ -70,23 +115,17 @@ const Template = ({
     hint ? `hint="${hint}"` : '',
     error ? 'error' : '',
     errorText ? `error-text="${errorText}"` : '',
-    icon ? 'icon' : '',
     prefix ? `prefix="${prefix}"` : '',
     suffix ? `suffix="${suffix}"` : '',
     disabled ? 'disabled' : '',
     Number.isFinite(Number(min)) ? `min="${Number(min)}"` : '',
     Number.isFinite(Number(max)) ? `max="${Number(max)}"` : '',
     Number.isFinite(Number(step)) ? `step="${Number(step)}"` : '',
-    forceState ? `force-state="${forceState}"` : '',
   ]
     .filter(Boolean)
-    .join(' ');
+    .join('\n  ');
 
-  return `
-    <div style="width: 244px;">
-      <lui-input ${attrs}></lui-input>
-    </div>
-  `;
+  return `<lui-input\n  ${attrs}\n >\n </lui-input>`;
 };
 
 export const Input = Template.bind({});
@@ -96,60 +135,147 @@ Input.args = {
   placeholder: 'Placeholder',
   value: '',
   size: 'lg',
+  name: '',
+  form: '',
+  required: false,
   optional: true,
   optionalText: '(opcional)',
   maxlength: 100,
   hint: 'Hint text',
   error: false,
   errorText: 'Campo obrigatório.',
-  icon: true,
   prefix: 'www.',
   suffix: '.com',
   disabled: false,
   min: undefined,
   max: undefined,
   step: undefined,
-  forceState: '',
 };
 
-export const Error = Template.bind({});
-Error.args = {
-  ...Input.args,
-  error: true,
-  hint: '',
+export const Error = () => `
+  <div style="width: 244px;">
+    <lui-input
+      label="Label"
+      placeholder="Placeholder"
+      size="lg"
+      error
+      error-text="Campo obrigatório."
+    ></lui-input>
+  </div>
+`;
+
+export const Disabled = () => `
+  <div style="width: 244px;">
+    <lui-input
+      label="Label"
+      placeholder="Placeholder"
+      value="Value"
+      size="lg"
+      disabled
+    ></lui-input>
+  </div>
+`;
+
+export const Password = () => `
+  <div style="width: 244px;">
+    <lui-input
+      type="password"
+      label="Senha"
+      placeholder="Digite sua senha"
+      value="%5sdad@dfsa45W"
+      size="lg"
+    ></lui-input>
+  </div>
+`;
+
+export const NumberInput = () => `
+  <div style="width: 244px;">
+    <lui-input
+      type="number"
+      label="Quantidade"
+      size="lg"
+      value="1"
+      min="0"
+      max="10"
+      step="1"
+    ></lui-input>
+  </div>
+`;
+
+export const Required = () => `
+  <div style="width: 244px;">
+    <lui-input
+      name="email"
+      label="E-mail"
+      placeholder="seu@email.com"
+      required
+      size="lg"
+      hint="Campo obrigatório."
+      error-text="E-mail é obrigatório."
+    ></lui-input>
+  </div>
+`;
+Required.parameters = {
+  docs: {
+    description: {
+      story:
+        'Com `required`, o campo bloqueia a submissão do form quando vazio e reporta o erro via `ElementInternals.setValidity()`. A mensagem de erro exibida é controlada pelo atributo `error-text`.',
+    },
+  },
 };
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...Input.args,
-  value: 'Value',
-  disabled: true,
-};
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 360px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="input-demo-form" style="display: flex; flex-direction: column; gap: 16px;">
+      <lui-input
+        name="name"
+        label="Nome"
+        placeholder="Digite seu nome"
+        required
+        size="lg"
+        error-text="Nome é obrigatório."
+      ></lui-input>
+      <lui-input
+        name="email"
+        label="E-mail"
+        placeholder="seu@email.com"
+        required
+        size="lg"
+        error-text="E-mail é obrigatório."
+      ></lui-input>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary" size="md">Limpar</lui-button>
+        <lui-button type="submit" variant="primary" size="md">Cadastrar</lui-button>
+      </div>
+    </form>
+    <p id="input-demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
 
-export const Password = Template.bind({});
-Password.args = {
-  ...Input.args,
-  type: 'password',
-  placeholder: 'Placeholder',
-  value: '%5sdad@dfsa45W',
-  icon: false,
-  prefix: '',
-  suffix: '',
-  optional: false,
-  hint: '',
-};
+  const form = container.querySelector('#input-demo-form');
+  const feedback = container.querySelector('#input-demo-feedback');
 
-export const NumberInput = Template.bind({});
-NumberInput.args = {
-  ...Input.args,
-  type: 'number',
-  value: '1',
-  icon: false,
-  prefix: '',
-  suffix: '',
-  optional: false,
-  hint: '',
-  min: 0,
-  max: 10,
-  step: 1,
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ Cadastrado: ${data.get('name')} <${data.get('email')}>`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  docs: {
+    description: {
+      story:
+        'Demonstração completa com `lui-input` e `lui-button` integrados ao mesmo form. Os valores de `name` e `e-mail` são capturados via `FormData`. Campos `required` bloqueiam a submissão quando vazios.',
+    },
+  },
 };

--- a/packages/lets-ui-components/src/components/input/input.ts
+++ b/packages/lets-ui-components/src/components/input/input.ts
@@ -153,8 +153,7 @@ export class LuiInput extends LitElement {
     this._charCount = 0;
     this.error = false;
     if (this._inputEl) this._inputEl.value = '';
-    this._internals.setFormValue(null);
-    this._internals.setValidity({});
+    this._syncFormValue();
   }
 
   private _syncFormValue() {

--- a/packages/lets-ui-components/src/components/input/input.ts
+++ b/packages/lets-ui-components/src/components/input/input.ts
@@ -52,7 +52,6 @@ export class LuiInput extends LitElement {
   @property() type = 'text';
   @property() name = '';
   @property() value = '';
-  @property() form = '';
   @property({ type: Boolean }) disabled = false;
   @property({ type: Boolean }) required = false;
   @property({ type: Boolean }) optional = false;

--- a/packages/lets-ui-components/src/components/input/input.ts
+++ b/packages/lets-ui-components/src/components/input/input.ts
@@ -1,5 +1,6 @@
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './input.scss?inline';
 
 const EYE_CLOSED = html`
@@ -41,13 +42,19 @@ const ICON_PLUS = html`
 
 export class LuiInput extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
 
   @property() label = '';
   @property() placeholder = '';
   @property() size = 'lg';
   @property() type = 'text';
+  @property() name = '';
   @property() value = '';
+  @property() form = '';
   @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean }) required = false;
   @property({ type: Boolean }) optional = false;
   @property({ attribute: 'optional-text' }) optionalText = '(opcional)';
   @property() hint = '';
@@ -72,6 +79,25 @@ export class LuiInput extends LitElement {
   constructor() {
     super();
     this._baseId = `lui-input-${Math.random().toString(36).slice(2, 9)}`;
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._internals.setFormValue(this.value);
+    this.addEventListener('invalid', () => {
+      this.error = true;
+    });
+  }
+
+  protected firstUpdated() {
+    this._syncFormValue();
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('value')) {
+      this._syncFormValue();
+    }
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {
@@ -119,11 +145,40 @@ export class LuiInput extends LitElement {
     return next;
   }
 
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this.value = '';
+    this._charCount = 0;
+    this.error = false;
+    if (this._inputEl) this._inputEl.value = '';
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+  }
+
+  private _syncFormValue() {
+    const val = this._inputEl?.value ?? '';
+    this._internals.setFormValue(val || null);
+    if (this.required && !val.trim()) {
+      this._internals.setValidity(
+        { valueMissing: true },
+        this.errorText,
+        this._inputEl
+      );
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
   private _handleInput() {
     if (this._inputType === 'number') {
       this._inputEl.value = String(this._clampNumber(this._inputEl.value));
     }
     this._charCount = this._inputEl.value.length;
+    this.error = false;
+    this._syncFormValue();
     this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
   }
 
@@ -131,6 +186,8 @@ export class LuiInput extends LitElement {
     if (this._inputType === 'number') {
       this._inputEl.value = String(this._clampNumber(this._inputEl.value));
     }
+    this.error = false;
+    this._syncFormValue();
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }
 
@@ -164,12 +221,14 @@ export class LuiInput extends LitElement {
           class="input-field__input"
           id="${this._baseId}-input"
           type="${inputRealType}"
+          name="${ifDefined(this.name || undefined)}"
           aria-label="${ariaLabel}"
           aria-describedby="${describedBy}"
           placeholder="${this.placeholder}"
           .value="${this.value}"
           maxlength="${maxLen !== null ? maxLen : ''}"
           ?disabled="${this.disabled}"
+          ?required="${this.required}"
           ?aria-disabled="${this.disabled}"
           @input="${this._handleInput}"
           @change="${this._handleChange}"
@@ -218,6 +277,7 @@ export class LuiInput extends LitElement {
           class="input-field__input input-field__input--number"
           id="${this._baseId}-input"
           type="number"
+          name="${ifDefined(this.name || undefined)}"
           aria-label="${ariaLabel}"
           aria-describedby="${describedBy}"
           .value="${this.value || '1'}"
@@ -225,6 +285,7 @@ export class LuiInput extends LitElement {
           min="${minVal !== null ? minVal : ''}"
           max="${maxVal !== null ? maxVal : ''}"
           ?disabled="${this.disabled}"
+          ?required="${this.required}"
           ?aria-disabled="${this.disabled}"
           @input="${this._handleInput}"
           @change="${this._handleChange}"

--- a/packages/lets-ui-components/src/components/radio-group/RadioGroup.docs.mdx
+++ b/packages/lets-ui-components/src/components/radio-group/RadioGroup.docs.mdx
@@ -1,0 +1,63 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as RadioGroupStories from './RadioGroup.stories';
+
+<Meta of={RadioGroupStories} />
+
+# Radio Group
+
+Agrupa múltiplos `lui-radio` em uma seleção exclusiva. Centraliza `name`, `required` e `error-text` no elemento pai — os filhos declaram apenas `value` e `label`.
+
+<Canvas of={RadioGroupStories.RadioGroup} />
+<Controls of={RadioGroupStories.RadioGroup} />
+
+## Hint
+
+Texto auxiliar exibido abaixo das opções. Substituído pela mensagem de `error-text` quando `error` é `true`.
+
+<Canvas of={RadioGroupStories.WithHint} />
+
+## Small
+
+`size="md"` aplica `body--md` na label do grupo, seguindo o mesmo padrão do `lui-input`.
+
+<Canvas of={RadioGroupStories.Small} />
+
+## Pré-selecionado
+
+Adicione `checked` ao `lui-radio` desejado para definir um valor inicial. O grupo sincroniza o `FormData` automaticamente ao conectar.
+
+<Canvas of={RadioGroupStories.PreSelected} />
+
+## Disabled
+
+`disabled` no grupo propaga o estado para todos os filhos e exclui o campo da submissão.
+
+<Canvas of={RadioGroupStories.Disabled} />
+
+## Integração com formulários
+
+### Required
+
+`required` no grupo bloqueia a submissão enquanto nenhuma opção estiver selecionada. O evento `invalid` dispara no grupo e a mensagem de `error-text` é exibida abaixo das opções, representando o grupo como um todo.
+
+<Canvas of={RadioGroupStories.Required} />
+
+### Form Integration
+
+O valor selecionado é submetido no `FormData` com a chave `name` do grupo. Múltiplos grupos independentes coexistem no mesmo form sem interferência.
+
+<Canvas of={RadioGroupStories.FormIntegration} />
+
+## Atributos
+
+| Atributo     | Tipo      | Padrão                  | Descrição                                                         |
+| ------------ | --------- | ----------------------- | ----------------------------------------------------------------- |
+| `name`       | `string`  | `''`                    | Chave do campo no `FormData`                                      |
+| `label`      | `string`  | `''`                    | Texto exibido como `<legend>` do grupo                            |
+| `size`       | `'lg' \| 'md'` | `'lg'`            | Tamanho da label: `lg` → `body--lg`, `md` → `body--md`           |
+| `hint`       | `string`  | `''`                    | Texto auxiliar abaixo das opções; substituído por `error-text` quando há erro |
+| `required`   | `boolean` | `false`                 | Bloqueia a submissão quando nenhuma opção está selecionada        |
+| `disabled`   | `boolean` | `false`                 | Desabilita todos os radios filhos e exclui o campo da submissão   |
+| `error`      | `boolean` | `false`                 | Ativa o estado de erro manualmente                                |
+| `error-text` | `string`  | `'Selecione uma opção.'`| Mensagem exibida abaixo do grupo quando `error` é verdadeiro      |
+| `form`       | `string`  | `''`                    | ID do `<form>` associado; permite usar o grupo fora do `<form>`   |

--- a/packages/lets-ui-components/src/components/radio-group/RadioGroup.stories.js
+++ b/packages/lets-ui-components/src/components/radio-group/RadioGroup.stories.js
@@ -1,0 +1,231 @@
+import '../../../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
+import '../../../../../packages/styles/dist/letsui.css';
+import '../../index.js';
+
+export default {
+  title: 'Form and options/Radio/Radio Group',
+  argTypes: {
+    label: { control: 'text' },
+    name: { control: 'text' },
+    hint: { control: 'text' },
+    'error-text': { control: 'text' },
+    size: {
+      control: { type: 'select' },
+      options: ['lg', 'md'],
+      table: { defaultValue: { summary: 'lg' } },
+    },
+    required: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    error: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+  },
+};
+
+const Template = ({
+  label,
+  name,
+  size,
+  hint,
+  required,
+  disabled,
+  error,
+  'error-text': errorText,
+}) => {
+  const attrs = [
+    `name="${name ?? 'group'}"`,
+    `size="${size ?? 'lg'}"`,
+    label ? `label="${label}"` : '',
+    hint ? `hint="${hint}"` : '',
+    errorText ? `error-text="${errorText}"` : '',
+    required ? 'required' : '',
+    disabled ? 'disabled' : '',
+    error ? 'error' : '',
+  ]
+    .filter(Boolean)
+    .join('\n  ');
+
+  return `
+<lui-radio-group
+  ${attrs}
+>
+  <lui-radio value="opt1" label="Opção 1"></lui-radio>
+  <lui-radio value="opt2" label="Opção 2"></lui-radio>
+  <lui-radio value="opt3" label="Opção 3"></lui-radio>
+</lui-radio-group>`;
+};
+
+export const RadioGroup = Template.bind({});
+RadioGroup.args = {
+  label: 'Escolha uma opção',
+  name: 'story-group',
+  size: 'lg',
+  hint: '',
+  required: false,
+  disabled: false,
+  error: false,
+  'error-text': 'Selecione uma opção.',
+};
+
+export const WithHint = () => `
+<lui-radio-group
+  name="plan"
+  label="Plano"
+  hint="Você pode alterar o plano a qualquer momento."
+>
+  <lui-radio value="free" label="Free — até 3 projetos"></lui-radio>
+  <lui-radio value="pro" label="Pro — projetos ilimitados"></lui-radio>
+  <lui-radio value="enterprise" label="Enterprise — sob consulta"></lui-radio>
+</lui-radio-group>`;
+WithHint.storyName = 'With Hint';
+WithHint.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'O `hint` aparece abaixo das opções em cor `caption`. Quando o evento `invalid` dispara e `error` passa a `true`, o hint é substituído pela mensagem de `error-text`.',
+    },
+  },
+};
+
+export const Small = () => `
+<lui-radio-group name="plan" label="Plano" size="md">
+  <lui-radio value="free" label="Free"></lui-radio>
+  <lui-radio value="pro" label="Pro"></lui-radio>
+  <lui-radio value="enterprise" label="Enterprise" disabled></lui-radio>
+</lui-radio-group>`;
+Small.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'Tamanho `md`: a label do grupo usa `body--md`, o mesmo padrão do `lui-input` em tamanho médio.',
+    },
+  },
+};
+
+export const PreSelected = () => `
+<lui-radio-group name="plan" label="Plano">
+  <lui-radio value="free" label="Free — até 3 projetos"></lui-radio>
+  <lui-radio value="pro" label="Pro — projetos ilimitados" checked></lui-radio>
+  <lui-radio value="enterprise" label="Enterprise — sob consulta"></lui-radio>
+</lui-radio-group>`;
+PreSelected.storyName = 'Pre-selected';
+PreSelected.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'Para definir um valor inicial, adicione `checked` ao `lui-radio` desejado. O grupo lê o estado dos filhos ao conectar e sincroniza o `FormData` automaticamente.',
+    },
+  },
+};
+
+export const Disabled = () => `
+<lui-radio-group name="plan" label="Plano" disabled>
+  <lui-radio value="free" label="Free"></lui-radio>
+  <lui-radio value="pro" label="Pro" checked></lui-radio>
+  <lui-radio value="enterprise" label="Enterprise"></lui-radio>
+</lui-radio-group>`;
+Disabled.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        '`disabled` no grupo propaga o estado para todos os filhos e impede a submissão do campo.',
+    },
+  },
+};
+
+export const Required = () => `
+<form id="rg-required-form" style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+  <lui-radio-group
+    name="plan"
+    label="Plano"
+    required
+    error-text="Selecione um plano para continuar."
+  >
+    <lui-radio value="free" label="Free — até 3 projetos"></lui-radio>
+    <lui-radio value="pro" label="Pro — projetos ilimitados"></lui-radio>
+    <lui-radio value="enterprise" label="Enterprise — sob consulta"></lui-radio>
+  </lui-radio-group>
+  <div style="display: flex; justify-content: flex-end;">
+    <lui-button type="submit" variant="primary">Continuar</lui-button>
+  </div>
+</form>`;
+Required.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        '`required` no grupo bloqueia a submissão quando nenhum radio está selecionado. Ao tentar submeter, o evento `invalid` dispara no grupo e a mensagem de `error-text` é exibida abaixo das opções.',
+    },
+  },
+};
+
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 400px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="rg-demo-form" style="display: flex; flex-direction: column; gap: 20px;">
+      <lui-radio-group
+        name="plan"
+        label="Plano"
+        required
+        error-text="Selecione um plano."
+      >
+        <lui-radio value="free" label="Free — até 3 projetos"></lui-radio>
+        <lui-radio value="pro" label="Pro — projetos ilimitados"></lui-radio>
+        <lui-radio value="enterprise" label="Enterprise — sob consulta"></lui-radio>
+      </lui-radio-group>
+      <lui-radio-group
+        name="billing"
+        label="Ciclo de cobrança"
+        required
+        error-text="Selecione o ciclo de cobrança."
+      >
+        <lui-radio value="monthly" label="Mensal"></lui-radio>
+        <lui-radio value="yearly" label="Anual (2 meses grátis)"></lui-radio>
+      </lui-radio-group>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary">Limpar</lui-button>
+        <lui-button type="submit" variant="primary">Confirmar</lui-button>
+      </div>
+    </form>
+    <p id="rg-demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
+
+  const form = container.querySelector('#rg-demo-form');
+  const feedback = container.querySelector('#rg-demo-feedback');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ plan: "${data.get('plan')}"  billing: "${data.get('billing')}"`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'O `lui-radio-group` é form-associated: o `value` do radio selecionado é submetido no `FormData` com a chave `name` do grupo. Reset limpa todos os filhos e restaura a validade.',
+    },
+  },
+};

--- a/packages/lets-ui-components/src/components/radio-group/radio-group.scss
+++ b/packages/lets-ui-components/src/components/radio-group/radio-group.scss
@@ -1,0 +1,5 @@
+@use 'packages/styles/src/components/radio-group' as *;
+
+:host {
+  display: block;
+}

--- a/packages/lets-ui-components/src/components/radio-group/radio-group.ts
+++ b/packages/lets-ui-components/src/components/radio-group/radio-group.ts
@@ -1,0 +1,139 @@
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
+import { property } from 'lit/decorators.js';
+import styles from './radio-group.scss?inline';
+import { LuiRadio } from '../radio/radio.js';
+
+export class LuiRadioGroup extends LitElement {
+  static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
+  private _value = '';
+
+  @property() name = '';
+  @property() label = '';
+  @property() size = 'lg';
+  @property() form = '';
+  @property({ type: Boolean }) required = false;
+  @property({ type: Boolean }) disabled = false;
+  @property() hint = '';
+  @property({ type: Boolean }) error = false;
+  @property({ attribute: 'error-text' }) errorText = 'Selecione uma opção.';
+
+  constructor() {
+    super();
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('invalid', () => {
+      this.error = true;
+    });
+    this.addEventListener('change', this._handleRadioChange);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('change', this._handleRadioChange);
+  }
+
+  protected firstUpdated() {
+    this._applyToRadios();
+    this._initFromChildren();
+    this._syncFormValue();
+  }
+
+  get _size(): 'lg' | 'md' {
+    return this.size === 'md' ? 'md' : 'lg';
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('disabled') || changed.has('size')) {
+      this._applyToRadios();
+    }
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this._value = '';
+    this.error = false;
+    this._getRadios().forEach((r) => {
+      r.checked = false;
+    });
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+    this.requestUpdate();
+  }
+
+  private _getRadios(): LuiRadio[] {
+    return Array.from(this.querySelectorAll<LuiRadio>('lui-radio'));
+  }
+
+  private _initFromChildren() {
+    const checked = this._getRadios().find((r) => r.checked);
+    if (checked) this._value = checked.value;
+  }
+
+  private _syncFormValue() {
+    this._internals.setFormValue(this._value || null);
+    if (this.required && !this._value) {
+      this._internals.setValidity({ valueMissing: true }, this.errorText);
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  private _handleRadioChange = (e: Event) => {
+    const radio = e.target;
+    if (!(radio instanceof LuiRadio) || !this.contains(radio)) return;
+    if (!radio.checked) return;
+
+    this._value = radio.value;
+    this.error = false;
+
+    this._getRadios().forEach((r) => {
+      if (r !== radio) r.checked = false;
+    });
+
+    this._syncFormValue();
+    this.requestUpdate();
+  };
+
+  private _applyToRadios() {
+    this._getRadios().forEach((r) => {
+      r.size = this._size;
+      if (this.disabled) r.disabled = true;
+    });
+  }
+
+  private _handleSlotChange() {
+    this._applyToRadios();
+    this._initFromChildren();
+    this._syncFormValue();
+  }
+
+  render() {
+    return html`
+      <fieldset
+        class="radio-group radio-group--${this._size}${this.error
+          ? ' radio-group--error'
+          : ''}"
+      >
+        ${this.label
+          ? html`<legend class="radio-group__legend">${this.label}</legend>`
+          : ''}
+        ${this.hint ? html`<p class="radio-group__hint">${this.hint}</p>` : ''}
+        <div class="radio-group__options">
+          <slot @slotchange=${this._handleSlotChange}></slot>
+        </div>
+        ${this.error && this.errorText
+          ? html`<p class="radio-group__message">${this.errorText}</p>`
+          : ''}
+      </fieldset>
+    `;
+  }
+}

--- a/packages/lets-ui-components/src/components/radio-group/radio-group.ts
+++ b/packages/lets-ui-components/src/components/radio-group/radio-group.ts
@@ -13,7 +13,6 @@ export class LuiRadioGroup extends LitElement {
   @property() name = '';
   @property() label = '';
   @property() size = 'lg';
-  @property() form = '';
   @property({ type: Boolean }) required = false;
   @property({ type: Boolean }) disabled = false;
   @property() hint = '';

--- a/packages/lets-ui-components/src/components/radio/Radio.docs.mdx
+++ b/packages/lets-ui-components/src/components/radio/Radio.docs.mdx
@@ -1,21 +1,39 @@
-import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as RadioStories from './Radio.stories';
 
 <Meta of={RadioStories} />
 
 # Radio
 
+Elemento de seleção única dentro de um grupo. O conteúdo da label é projetado via slot — o atributo `label` serve como fallback para texto simples.
+
 <Canvas of={RadioStories.Radio} />
 <Controls of={RadioStories.Radio} />
 
+## Label (atributo)
+
+O atributo `label` renderiza o texto como conteúdo padrão do slot. Útil para casos simples ou geração programática de HTML.
+
+<Canvas of={RadioStories.LabelAttribute} />
+
 ## Checked
+
 <Canvas of={RadioStories.Checked} />
 
 ## Small
+
 <Canvas of={RadioStories.Small} />
 
 ## Disabled
+
 <Canvas of={RadioStories.Disabled} />
 
-## Group
-<Canvas of={RadioStories.Group} />
+## Atributos
+
+| Atributo     | Tipo            | Padrão | Descrição                                                   |
+| ------------ | --------------- | ------ | ----------------------------------------------------------- |
+| `label`      | `string`        | `''`   | Conteúdo padrão do slot; ignorado quando o slot é projetado |
+| `value`      | `string`        | `''`   | Valor submetido pelo grupo quando este radio estiver marcado |
+| `checked`    | `boolean`       | `false`| Estado marcado                                              |
+| `disabled`   | `boolean`       | `false`| Desabilita o radio                                          |
+| `size`       | `'lg' \| 'md'` | `'lg'` | Controlado pelo `lui-radio-group`; raramente definido direto|

--- a/packages/lets-ui-components/src/components/radio/Radio.stories.js
+++ b/packages/lets-ui-components/src/components/radio/Radio.stories.js
@@ -6,62 +6,63 @@ export default {
   title: 'Form and options/Radio',
   argTypes: {
     label: { control: 'text' },
-    checked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    value: { control: 'text' },
+    checked: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     size: {
       control: { type: 'select' },
       options: ['lg', 'md'],
+      table: { defaultValue: { summary: 'lg' } },
     },
   },
 };
 
-const Template = ({ label, checked, disabled, size }) =>
-  `<lui-radio
-    label="${label ?? ''}"
-    size="${size}"
-    name="story-radio"
-    value="${label ?? ''}"
-    ${checked ? 'checked' : ''}
-    ${disabled ? 'disabled' : ''}
-  ></lui-radio>`;
+const Template = ({ label, value, checked, disabled, size }) => {
+  const attrs = [
+    `size="${size ?? 'lg'}"`,
+    value ? `value="${value}"` : '',
+    checked ? 'checked' : '',
+    disabled ? 'disabled' : '',
+  ]
+    .filter(Boolean)
+    .join('\n  ');
+
+  return `<lui-radio\n  ${attrs}\n>\n  ${label ?? ''}\n</lui-radio>`;
+};
 
 export const Radio = Template.bind({});
 Radio.args = {
   label: 'Radio label',
+  value: 'option',
   checked: false,
   disabled: false,
   size: 'lg',
 };
 
-export const Checked = Template.bind({});
-Checked.args = {
-  label: 'Selected option',
-  checked: true,
-  disabled: false,
-  size: 'lg',
+export const LabelAttribute = () =>
+  `<lui-radio label="Opção via atributo" value="option" size="lg"></lui-radio>`;
+LabelAttribute.storyName = 'Label (atributo)';
+LabelAttribute.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'Fallback para texto simples: o atributo `label` é renderizado como conteúdo padrão do slot quando nenhum conteúdo é projetado.',
+    },
+  },
 };
 
-export const Small = Template.bind({});
-Small.args = {
-  label: 'Label',
-  checked: false,
-  disabled: false,
-  size: 'md',
-};
+export const Checked = () =>
+  `<lui-radio value="selected" checked size="lg">Opção selecionada</lui-radio>`;
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  label: 'Label',
-  checked: true,
-  disabled: true,
-  size: 'lg',
-};
+export const Small = () =>
+  `<lui-radio value="option" size="md">Label</lui-radio>`;
 
-export const Group = () => `
-  <div style="display: flex; flex-direction: column; gap: 8px;">
-    <lui-radio label="Opção 1" name="story-group" value="opt1" checked size="lg"></lui-radio>
-    <lui-radio label="Opção 2" name="story-group" value="opt2" size="lg"></lui-radio>
-    <lui-radio label="Opção 3 (desabilitado)" name="story-group" value="opt3" disabled size="lg"></lui-radio>
-  </div>
-`;
-Group.parameters = { controls: { disable: true } };
+export const Disabled = () =>
+  `<lui-radio value="option" checked disabled size="lg">Desabilitado</lui-radio>`;

--- a/packages/lets-ui-components/src/components/radio/radio.ts
+++ b/packages/lets-ui-components/src/components/radio/radio.ts
@@ -1,16 +1,18 @@
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 import styles from './radio.scss?inline';
 
 export class LuiRadio extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
 
   @property() label = '';
+  @property() value = '';
   @property({ type: Boolean }) checked = false;
   @property({ type: Boolean }) disabled = false;
   @property() size = 'lg';
-  @property() name = '';
-  @property() value = '';
   @property({ attribute: 'aria-label' }) ariaLabel = '';
 
   private _baseId: string;
@@ -18,6 +20,31 @@ export class LuiRadio extends LitElement {
   constructor() {
     super();
     this._baseId = `lui-radio-${Math.random().toString(36).slice(2, 9)}`;
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._internals.setFormValue(this.checked ? this.value : null);
+  }
+
+  protected firstUpdated() {
+    this._syncFormValue();
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('checked')) {
+      this._syncFormValue();
+    }
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this.checked = false;
+    this._internals.setFormValue(null);
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {
@@ -29,11 +56,25 @@ export class LuiRadio extends LitElement {
       : 'lg';
   }
 
-  private _handleChange(e: Event) {
+  private _syncFormValue() {
+    this._internals.setFormValue(this.checked ? this.value : null);
+    this._internals.setValidity({});
+  }
+
+  private _uncheckSiblings() {
+    const group = this.closest('lui-radio-group');
+    if (!group) return;
+    group.querySelectorAll('lui-radio').forEach((el) => {
+      if (el !== this) (el as LuiRadio).checked = false;
+    });
+  }
+
+  private _handleChange = (e: Event) => {
     const input = e.target as HTMLInputElement;
     this.checked = input.checked;
+    if (this.checked) this._uncheckSiblings();
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
-  }
+  };
 
   render() {
     const ariaLabel = this.ariaLabel || this.label || 'Radio';
@@ -42,15 +83,14 @@ export class LuiRadio extends LitElement {
         <input
           id="${this._baseId}-input"
           type="radio"
-          aria-label="${ariaLabel}"
-          name="${this.name}"
           value="${this.value}"
+          aria-label="${ariaLabel}"
           .checked="${this.checked}"
           ?disabled="${this.disabled}"
           ?aria-disabled="${this.disabled}"
           @change="${this._handleChange}"
         />
-        <span id="${this._baseId}-label">${this.label}</span>
+        <slot>${this.label}</slot>
       </label>
     `;
   }

--- a/packages/lets-ui-components/src/components/select/Select.docs.mdx
+++ b/packages/lets-ui-components/src/components/select/Select.docs.mdx
@@ -1,21 +1,41 @@
-import { Meta, Canvas, Controls, ArgTypes } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as SelectStories from './Select.stories';
 
 <Meta of={SelectStories} />
 
 # Native Select
 
+Select nativo com estilização customizada. O valor da opção selecionada é submetido no `FormData` com a chave `name`.
+
 <Canvas of={SelectStories.NativeSelect} />
 <Controls of={SelectStories.NativeSelect} />
 
-## Hover
-<Canvas of={SelectStories.Hover} />
-
-## Focus
-<Canvas of={SelectStories.Focus} />
-
 ## Error
+
 <Canvas of={SelectStories.Error} />
 
 ## Disabled
+
 <Canvas of={SelectStories.Disabled} />
+
+## Integração com formulários
+
+O `lui-native-select` é form-associated. O valor da opção selecionada é submetido via `FormData` com a chave `name`. Use `form` para associá-lo a um form por ID mesmo estando fora do `<form>`.
+
+### Required
+
+Com `required`, o form não submete enquanto o placeholder estiver ativo (nenhuma opção real selecionada).
+
+<Canvas of={SelectStories.Required} />
+
+### Form Integration
+
+<Canvas of={SelectStories.FormIntegration} />
+
+## Atributos de formulário
+
+| Atributo   | Tipo      | Padrão | Descrição                                                                        |
+| ---------- | --------- | ------ | -------------------------------------------------------------------------------- |
+| `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`       |
+| `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o select fora do elemento form            |
+| `required` | `boolean` | `false`| Bloqueia a submissão enquanto o placeholder estiver selecionado                  |

--- a/packages/lets-ui-components/src/components/select/Select.stories.js
+++ b/packages/lets-ui-components/src/components/select/Select.stories.js
@@ -6,41 +6,59 @@ export default {
   title: 'Form and options/Native Select',
   argTypes: {
     label: { control: 'text' },
-    placeholder: { control: 'text' },
-    options: { control: 'text' },
-    selected: { control: 'number' },
-    optional: { control: 'boolean' },
+    placeholder: {
+      control: 'text',
+      table: { defaultValue: { summary: 'Select an option' } },
+    },
+    options: {
+      control: 'text',
+      table: { defaultValue: { summary: 'Option 1,Option 2,Option 3' } },
+    },
+    selected: { control: 'number', table: { defaultValue: { summary: '0' } } },
+    name: { control: 'text' },
+    form: { control: 'text' },
+    required: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    optional: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     optionalText: { control: 'text' },
     hint: { control: 'text' },
-    error: { control: 'boolean' },
+    error: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     errorText: { control: 'text' },
-    icon: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     size: {
       control: { type: 'select' },
       options: ['lg', 'md', 'sm'],
-    },
-    forceState: {
-      control: { type: 'select' },
-      options: ['', 'hovered', 'focused'],
+      table: { defaultValue: { summary: 'lg' } },
     },
   },
 };
 
 const Template = ({
-  label = 'Label',
-  placeholder = 'Select an option',
-  options = 'Option 1,Option 2',
-  selected = 0,
+  label,
+  placeholder,
+  options,
+  selected,
+  name,
+  form,
+  required,
   optional,
   optionalText,
   hint,
   error,
   errorText,
-  icon,
   disabled,
-  size = 'lg',
-  forceState,
+  size,
 }) => {
   const attrs = [
     `label="${label ?? ''}"`,
@@ -48,23 +66,20 @@ const Template = ({
     `options="${options ?? ''}"`,
     Number.isFinite(Number(selected)) ? `selected="${Number(selected)}"` : '',
     `size="${size ?? 'lg'}"`,
+    name ? `name="${name}"` : '',
+    form ? `form="${form}"` : '',
+    required ? 'required' : '',
     optional ? 'optional' : '',
     optionalText ? `optional-text="${optionalText}"` : '',
     hint ? `hint="${hint}"` : '',
     error ? 'error' : '',
     errorText ? `error-text="${errorText}"` : '',
-    icon ? 'icon' : '',
     disabled ? 'disabled' : '',
-    forceState ? `force-state="${forceState}"` : '',
   ]
     .filter(Boolean)
-    .join(' ');
+    .join('\n    ');
 
-  return `
-    <div style="width: 244px;">
-      <lui-native-select ${attrs}></lui-native-select>
-    </div>
-  `;
+  return `<div style="width: 244px;">\n  <lui-native-select\n    ${attrs}\n  ></lui-native-select>\n</div>`;
 };
 
 export const NativeSelect = Template.bind({});
@@ -73,39 +88,119 @@ NativeSelect.args = {
   placeholder: 'Select an option',
   options: 'Option 1,Option 2,Option 3',
   selected: 1,
+  name: '',
+  form: '',
+  required: false,
   optional: true,
   optionalText: '(opcional)',
   hint: 'Hint text',
   error: false,
   errorText: 'Campo obrigatório.',
-  icon: true,
   disabled: false,
   size: 'lg',
-  forceState: '',
 };
 
-export const Hover = Template.bind({});
-Hover.args = {
-  ...NativeSelect.args,
-  forceState: 'hovered',
+export const Error = () => `
+  <div style="width: 244px;">
+    <lui-native-select
+      label="Label"
+      options="Option 1,Option 2,Option 3"
+      selected="0"
+      size="lg"
+      error
+      error-text="Campo obrigatório."
+    ></lui-native-select>
+  </div>
+`;
+
+export const Disabled = () => `
+  <div style="width: 244px;">
+    <lui-native-select
+      label="Label"
+      options="Option 1,Option 2,Option 3"
+      selected="1"
+      size="lg"
+      disabled
+    ></lui-native-select>
+  </div>
+`;
+
+export const Required = () => `
+  <div style="width: 244px;">
+    <lui-native-select
+      name="category"
+      label="Categoria"
+      placeholder="Selecione uma categoria"
+      options="Design,Engenharia,Produto"
+      size="lg"
+      required
+      error-text="Selecione uma categoria."
+    ></lui-native-select>
+  </div>
+`;
+Required.parameters = {
+  docs: {
+    description: {
+      story:
+        'Com `required`, o form não submete enquanto o placeholder estiver selecionado (nenhuma opção real escolhida).',
+    },
+  },
 };
 
-export const Focus = Template.bind({});
-Focus.args = {
-  ...NativeSelect.args,
-  forceState: 'focused',
-};
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 360px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="select-demo-form" style="display: flex; flex-direction: column; gap: 16px;">
+      <lui-native-select
+        name="role"
+        label="Função"
+        placeholder="Selecione sua função"
+        options="Design,Engenharia,Produto,Marketing"
+        size="lg"
+        required
+        error-text="Selecione uma função."
+      ></lui-native-select>
+      <lui-native-select
+        name="seniority"
+        label="Senioridade"
+        placeholder="Selecione a senioridade"
+        options="Júnior,Pleno,Sênior,Staff"
+        size="lg"
+        required
+        error-text="Selecione a senioridade."
+      ></lui-native-select>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary" size="md">Limpar</lui-button>
+        <lui-button type="submit" variant="primary" size="md">Salvar</lui-button>
+      </div>
+    </form>
+    <p id="select-demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
 
-export const Error = Template.bind({});
-Error.args = {
-  ...NativeSelect.args,
-  selected: 0,
-  hint: '',
-  error: true,
-};
+  const form = container.querySelector('#select-demo-form');
+  const feedback = container.querySelector('#select-demo-feedback');
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...NativeSelect.args,
-  disabled: true,
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ ${data.get('role')} · ${data.get('seniority')}`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  docs: {
+    description: {
+      story:
+        'O valor da opção selecionada é submetido via `FormData` com a chave `name`. `required` bloqueia a submissão enquanto o placeholder estiver ativo.',
+    },
+  },
 };

--- a/packages/lets-ui-components/src/components/select/select.ts
+++ b/packages/lets-ui-components/src/components/select/select.ts
@@ -64,7 +64,7 @@ export class LuiSelect extends LitElement {
   formResetCallback() {
     this.selected = 0;
     this.error = false;
-    this._internals.setValidity({});
+    this._syncFormValue();
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {

--- a/packages/lets-ui-components/src/components/select/select.ts
+++ b/packages/lets-ui-components/src/components/select/select.ts
@@ -1,14 +1,21 @@
-import { LitElement, html, unsafeCSS } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
+import { property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './select.scss?inline';
 
 export class LuiSelect extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
 
   @property() label = '';
+  @property() name = '';
+  @property() form = '';
   @property() options = 'Option 1,Option 2,Option 3';
   @property({ type: Number }) selected = 0;
   @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean }) required = false;
   @property() size = 'lg';
   @property({ type: Boolean }) optional = false;
   @property({ attribute: 'optional-text' }) optionalText = '(opcional)';
@@ -21,11 +28,44 @@ export class LuiSelect extends LitElement {
 
   @state() private _selectedIndex = 0;
 
+  @query('.native-select__input') private _selectEl!: HTMLSelectElement;
+
   private _baseId: string;
 
   constructor() {
     super();
     this._baseId = `lui-select-${Math.random().toString(36).slice(2, 9)}`;
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    const idx = Number.isFinite(this.selected) ? Math.max(this.selected, 0) : 0;
+    const val = idx > 0 ? this._parsedOptions[idx - 1] : null;
+    this._internals.setFormValue(val || null);
+    this.addEventListener('invalid', () => {
+      this.error = true;
+    });
+  }
+
+  protected firstUpdated() {
+    this._syncFormValue();
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('selected')) {
+      this._syncFormValue();
+    }
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this.selected = 0;
+    this.error = false;
+    this._internals.setValidity({});
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {
@@ -44,12 +84,28 @@ export class LuiSelect extends LitElement {
       .filter(Boolean);
   }
 
-  private _handleChange(e: Event) {
+  private _syncFormValue() {
+    const idx = Number.isFinite(this.selected) ? Math.max(this.selected, 0) : 0;
+    const selectedValue = idx > 0 ? this._parsedOptions[idx - 1] : null;
+    this._internals.setFormValue(selectedValue || null);
+    if (this.required && !selectedValue) {
+      this._internals.setValidity(
+        { valueMissing: true },
+        this.errorText,
+        this._selectEl
+      );
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  private _handleChange = (e: Event) => {
     const select = e.target as HTMLSelectElement;
     this._selectedIndex = select.selectedIndex;
     this.selected = select.selectedIndex;
+    this.error = false;
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
-  }
+  };
 
   render() {
     const ariaLabel = this.ariaLabel || this.label || 'Native select';
@@ -90,9 +146,11 @@ export class LuiSelect extends LitElement {
           <select
             class="native-select__input"
             id="${this._baseId}-input"
+            name="${ifDefined(this.name || undefined)}"
             aria-label="${ariaLabel}"
             aria-describedby="${describedBy}"
             ?disabled="${this.disabled}"
+            ?required="${this.required}"
             ?aria-disabled="${this.disabled}"
             @change="${this._handleChange}"
           >

--- a/packages/lets-ui-components/src/components/select/select.ts
+++ b/packages/lets-ui-components/src/components/select/select.ts
@@ -11,7 +11,6 @@ export class LuiSelect extends LitElement {
 
   @property() label = '';
   @property() name = '';
-  @property() form = '';
   @property() options = 'Option 1,Option 2,Option 3';
   @property({ type: Number }) selected = 0;
   @property({ type: Boolean }) disabled = false;

--- a/packages/lets-ui-components/src/components/switch/Switch.docs.mdx
+++ b/packages/lets-ui-components/src/components/switch/Switch.docs.mdx
@@ -5,10 +5,16 @@ import * as SwitchStories from './Switch.stories';
 
 # Switch
 
-Controle de alternância binária (ligado/desligado). Suporta quatro tamanhos, estado desabilitado e label associada via atributo `label`.
+Controle de alternância binária (ligado/desligado). O conteúdo da label é projetado via slot — o atributo `label` serve como fallback para texto simples.
 
 <Canvas of={SwitchStories.Default} />
 <Controls of={SwitchStories.Default} />
+
+## Label (atributo)
+
+O atributo `label` renderiza o texto como conteúdo padrão do slot. Útil para casos simples ou geração programática de HTML.
+
+<Canvas of={SwitchStories.LabelAttribute} />
 
 ## Estados
 
@@ -31,3 +37,19 @@ Controle de alternância binária (ligado/desligado). Suporta quatro tamanhos, e
 ## Grupo
 
 <Canvas of={SwitchStories.Group} />
+
+## Integração com formulários
+
+O `lui-switch` é form-associated. Use `name` para identificar o campo no `FormData` e `value` para definir o que é submetido quando ativado (padrão `"on"`).
+
+<Canvas of={SwitchStories.FormIntegration} />
+
+## Atributos de formulário
+
+| Atributo   | Tipo      | Padrão | Descrição                                                                       |
+| ---------- | --------- | ------ | ------------------------------------------------------------------------------- |
+| `label`    | `string`  | `''`   | Conteúdo padrão do slot; ignorado quando o slot é projetado                     |
+| `name`     | `string`  | `''`   | Nome do campo nos dados submetidos                                              |
+| `value`    | `string`  | `'on'` | Valor submetido quando ativado; omitido quando desativado                       |
+| `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o switch fora do elemento form           |
+| `required` | `boolean` | `false`| Bloqueia a submissão quando o switch não está ativado                           |

--- a/packages/lets-ui-components/src/components/switch/Switch.stories.js
+++ b/packages/lets-ui-components/src/components/switch/Switch.stories.js
@@ -6,68 +6,141 @@ export default {
   title: 'Form and options/Switch',
   argTypes: {
     label: { control: 'text' },
-    checked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    name: { control: 'text' },
+    value: { control: 'text', table: { defaultValue: { summary: 'on' } } },
+    form: { control: 'text' },
+    checked: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     size: {
       control: { type: 'select' },
       options: ['lg', 'md'],
+      table: { defaultValue: { summary: 'lg' } },
     },
   },
 };
 
-const Template = ({ label, checked, disabled, size }) =>
-  `<lui-switch
-    label="${label ?? ''}"
-    size="${size}"
-    ${checked ? 'checked' : ''}
-    ${disabled ? 'disabled' : ''}
-  ></lui-switch>`;
+const Template = ({
+  label,
+  name,
+  value,
+  form,
+  checked,
+  disabled,
+  required,
+  size,
+}) => {
+  const attrs = [
+    `size="${size ?? 'lg'}"`,
+    name ? `name="${name}"` : '',
+    value && value !== 'on' ? `value="${value}"` : '',
+    form ? `form="${form}"` : '',
+    checked ? 'checked' : '',
+    disabled ? 'disabled' : '',
+    required ? 'required' : '',
+  ]
+    .filter(Boolean)
+    .join('\n  ');
+
+  return `<lui-switch\n  ${attrs}\n>\n  ${label ?? ''}\n</lui-switch>`;
+};
 
 export const Default = Template.bind({});
 Default.args = {
   label: 'Switch label',
+  name: '',
+  value: 'on',
+  form: '',
   checked: false,
   disabled: false,
+  required: false,
   size: 'lg',
 };
 
-export const Checked = Template.bind({});
-Checked.args = {
-  label: 'Ativado',
-  checked: true,
-  disabled: false,
-  size: 'lg',
+export const LabelAttribute = () =>
+  `<lui-switch label="Opção via atributo" size="lg"></lui-switch>`;
+LabelAttribute.storyName = 'Label (atributo)';
+LabelAttribute.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'Fallback para texto simples: o atributo `label` é renderizado como conteúdo padrão do slot quando nenhum conteúdo é projetado.',
+    },
+  },
 };
 
-export const Small = Template.bind({});
-Small.args = {
-  label: 'Label',
-  checked: false,
-  disabled: false,
-  size: 'md',
-};
+export const Checked = () =>
+  `<lui-switch checked size="lg">Ativado</lui-switch>`;
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  label: 'Desabilitado',
-  checked: false,
-  disabled: true,
-  size: 'lg',
-};
+export const Small = () => `<lui-switch size="md">Label</lui-switch>`;
 
-export const DisabledChecked = Template.bind({});
-DisabledChecked.args = {
-  label: 'Desabilitado ativado',
-  checked: true,
-  disabled: true,
-  size: 'lg',
-};
+export const Disabled = () =>
+  `<lui-switch disabled size="lg">Desabilitado</lui-switch>`;
+
+export const DisabledChecked = () =>
+  `<lui-switch checked disabled size="lg">Desabilitado ativado</lui-switch>`;
 
 export const Group = () => `
   <div style="display: flex; flex-direction: column; gap: 12px;">
-    <lui-switch label="Receber notificações" checked size="lg"></lui-switch>
-    <lui-switch label="Modo escuro" size="lg"></lui-switch>
-    <lui-switch label="Salvar histórico (desabilitado)" disabled size="lg"></lui-switch>
+    <lui-switch checked size="lg">Receber notificações</lui-switch>
+    <lui-switch size="lg">Modo escuro</lui-switch>
+    <lui-switch disabled size="lg">Salvar histórico (desabilitado)</lui-switch>
   </div>
 `;
 Group.parameters = { controls: { disable: true } };
+
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 360px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="switch-demo-form" style="display: flex; flex-direction: column; gap: 16px;">
+      <div style="display: flex; flex-direction: column; gap: 12px;">
+        <lui-switch name="notifications" value="enabled" checked size="lg">Receber notificações</lui-switch>
+        <lui-switch name="darkmode" value="enabled" size="lg">Modo escuro</lui-switch>
+      </div>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary" size="md">Cancelar</lui-button>
+        <lui-button type="submit" variant="primary" size="md">Salvar</lui-button>
+      </div>
+    </form>
+    <p id="switch-demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
+
+  const form = container.querySelector('#switch-demo-form');
+  const feedback = container.querySelector('#switch-demo-feedback');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    const notifications = data.get('notifications') ? 'ativado' : 'desativado';
+    const darkmode = data.get('darkmode') ? 'ativado' : 'desativado';
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ Notificações: ${notifications} · Modo escuro: ${darkmode}`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  docs: {
+    description: {
+      story:
+        'Quando ativado, submete `value` no `FormData` com a chave `name`. Quando desativado, o campo é omitido — idêntico ao comportamento nativo de checkbox.',
+    },
+  },
+};

--- a/packages/lets-ui-components/src/components/switch/switch.scss
+++ b/packages/lets-ui-components/src/components/switch/switch.scss
@@ -1,5 +1,5 @@
 @use 'packages/styles/src/components/switch' as *;
 
 :host {
-  display: inline-flex;
+  display: block;
 }

--- a/packages/lets-ui-components/src/components/switch/switch.ts
+++ b/packages/lets-ui-components/src/components/switch/switch.ts
@@ -1,21 +1,59 @@
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './switch.scss?inline';
 
 export class LuiSwitch extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
 
   @property() label = '';
+  @property() name = '';
+  @property() value = 'on';
+  @property() form = '';
   @property({ type: Boolean }) checked = false;
   @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean }) required = false;
   @property() size = 'lg';
   @property({ attribute: 'aria-label' }) ariaLabel = '';
+  @property({ type: Boolean }) error = false;
+  @property({ attribute: 'error-text' }) errorText = 'Campo obrigatório.';
 
   private _baseId: string;
 
   constructor() {
     super();
     this._baseId = `lui-switch-${Math.random().toString(36).slice(2, 9)}`;
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._internals.setFormValue(this.checked ? this.value : null);
+    this.addEventListener('invalid', () => {
+      this.error = true;
+    });
+  }
+
+  protected firstUpdated() {
+    this._syncFormValue();
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('checked')) {
+      this._syncFormValue();
+    }
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this.checked = false;
+    this.error = false;
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {
@@ -27,29 +65,47 @@ export class LuiSwitch extends LitElement {
       : 'lg';
   }
 
-  private _handleChange(e: Event) {
+  private _syncFormValue() {
+    this._internals.setFormValue(this.checked ? this.value : null);
+    if (this.required && !this.checked) {
+      this._internals.setValidity({ valueMissing: true }, 'Campo obrigatório.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  private _handleChange = (e: Event) => {
     const input = e.target as HTMLInputElement;
     this.checked = input.checked;
+    if (this.checked) this.error = false;
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
-  }
+  };
 
   render() {
     const ariaLabel = this.ariaLabel || this.label || 'Switch';
     return html`
-      <label class="switch switch--${this._size}">
-        <input
-          id="${this._baseId}-input"
-          type="checkbox"
-          role="switch"
-          aria-label="${ariaLabel}"
-          aria-checked="${this.checked}"
-          .checked="${this.checked}"
-          ?disabled="${this.disabled}"
-          ?aria-disabled="${this.disabled}"
-          @change="${this._handleChange}"
-        />
-        <span id="${this._baseId}-label">${this.label}</span>
-      </label>
+      <div class="switch-field${this.error ? ' switch-field--error' : ''}">
+        <label class="switch switch--${this._size}">
+          <input
+            id="${this._baseId}-input"
+            type="checkbox"
+            role="switch"
+            name="${ifDefined(this.name || undefined)}"
+            .value="${this.value}"
+            aria-label="${ariaLabel}"
+            aria-checked="${this.checked}"
+            .checked="${this.checked}"
+            ?disabled="${this.disabled}"
+            ?required="${this.required}"
+            ?aria-disabled="${this.disabled}"
+            @change="${this._handleChange}"
+          />
+          <slot>${this.label}</slot>
+        </label>
+        ${this.error && this.errorText
+          ? html`<p class="switch-field__message">${this.errorText}</p>`
+          : ''}
+      </div>
     `;
   }
 }

--- a/packages/lets-ui-components/src/components/switch/switch.ts
+++ b/packages/lets-ui-components/src/components/switch/switch.ts
@@ -12,7 +12,6 @@ export class LuiSwitch extends LitElement {
   @property() label = '';
   @property() name = '';
   @property() value = 'on';
-  @property() form = '';
   @property({ type: Boolean }) checked = false;
   @property({ type: Boolean }) disabled = false;
   @property({ type: Boolean }) required = false;

--- a/packages/lets-ui-components/src/components/textarea/Textarea.docs.mdx
+++ b/packages/lets-ui-components/src/components/textarea/Textarea.docs.mdx
@@ -33,3 +33,25 @@ Use quando o conteúdo deve ser exibido mas não editado no contexto atual.
 Use `resize="none"` quando o layout não deve ser perturbado pelo redimensionamento — como em caixas de mensagem embutidas em formulários fixos.
 
 <Canvas of={TextareaStories.NoResize} />
+
+## Integração com formulários
+
+O `lui-textarea` é form-associated — seu valor é capturado automaticamente pelo `FormData` do form pai através do atributo `name`. O atributo `form` permite associá-lo a um form por ID mesmo estando fora do elemento `<form>`.
+
+### Required
+
+Com `required`, o campo bloqueia a submissão quando está vazio via `ElementInternals.setValidity()`.
+
+<Canvas of={TextareaStories.Required} />
+
+### Form Integration
+
+<Canvas of={TextareaStories.FormIntegration} />
+
+## Atributos de formulário
+
+| Atributo   | Tipo      | Padrão | Descrição                                                                     |
+| ---------- | --------- | ------ | ----------------------------------------------------------------------------- |
+| `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`    |
+| `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o textarea fora do elemento form       |
+| `required` | `boolean` | `false`| Bloqueia a submissão quando o campo está vazio; valida via `ElementInternals` |

--- a/packages/lets-ui-components/src/components/textarea/Textarea.stories.js
+++ b/packages/lets-ui-components/src/components/textarea/Textarea.stories.js
@@ -11,22 +11,35 @@ export default {
     size: {
       control: { type: 'select' },
       options: ['lg', 'md', 'sm'],
+      table: { defaultValue: { summary: 'lg' } },
     },
-    rows: { control: 'number' },
+    name: { control: 'text' },
+    form: { control: 'text' },
+    required: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    rows: { control: 'number', table: { defaultValue: { summary: '4' } } },
     resize: {
       control: { type: 'select' },
       options: ['vertical', 'none', 'both'],
+      table: { defaultValue: { summary: 'vertical' } },
     },
-    optional: { control: 'boolean' },
+    optional: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     optionalText: { control: 'text' },
     maxlength: { control: 'number' },
     hint: { control: 'text' },
-    error: { control: 'boolean' },
+    error: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     errorText: { control: 'text' },
-    disabled: { control: 'boolean' },
-    forceState: {
-      control: { type: 'select' },
-      options: ['', 'hovered', 'focused'],
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
     },
   },
 };
@@ -36,6 +49,9 @@ const Template = ({
   placeholder,
   value,
   size,
+  name,
+  form,
+  required,
   rows,
   resize,
   optional,
@@ -45,13 +61,15 @@ const Template = ({
   error,
   errorText,
   disabled,
-  forceState,
 }) => {
   const attrs = [
     `label="${label ?? ''}"`,
     `placeholder="${placeholder ?? ''}"`,
     value ? `value="${value}"` : '',
     `size="${size ?? 'lg'}"`,
+    name ? `name="${name}"` : '',
+    form ? `form="${form}"` : '',
+    required ? 'required' : '',
     rows ? `rows="${rows}"` : '',
     resize && resize !== 'vertical' ? `resize="${resize}"` : '',
     optional ? 'optional' : '',
@@ -63,16 +81,11 @@ const Template = ({
     error ? 'error' : '',
     errorText ? `error-text="${errorText}"` : '',
     disabled ? 'disabled' : '',
-    forceState ? `force-state="${forceState}"` : '',
   ]
     .filter(Boolean)
-    .join(' ');
+    .join('\n    ');
 
-  return `
-    <div style="width: 320px;">
-      <lui-textarea ${attrs}></lui-textarea>
-    </div>
-  `;
+  return `<div style="width: 320px;">\n  <lui-textarea\n    ${attrs}\n  ></lui-textarea>\n</div>`;
 };
 
 export const Textarea = Template.bind({});
@@ -81,6 +94,9 @@ Textarea.args = {
   placeholder: 'Placeholder',
   value: '',
   size: 'lg',
+  name: '',
+  form: '',
+  required: false,
   rows: 4,
   resize: 'vertical',
   optional: true,
@@ -90,46 +106,123 @@ Textarea.args = {
   error: false,
   errorText: 'Campo obrigatório.',
   disabled: false,
-  forceState: '',
 };
 
-export const WithCounter = Template.bind({});
-WithCounter.args = {
-  ...Textarea.args,
-  label: 'Descrição',
-  placeholder: 'Escreva uma descrição...',
-  maxlength: 200,
-  hint: '',
-  optional: false,
-};
+export const WithCounter = () => `
+  <div style="width: 320px;">
+    <lui-textarea
+      label="Descrição"
+      placeholder="Escreva uma descrição..."
+      size="lg"
+      maxlength="200"
+    ></lui-textarea>
+  </div>
+`;
+WithCounter.storyName = 'With Counter';
 
-export const Error = Template.bind({});
-Error.args = {
-  ...Textarea.args,
-  label: 'Observações',
-  placeholder: 'Escreva suas observações...',
-  hint: '',
-  error: true,
-  optional: false,
-};
+export const Error = () => `
+  <div style="width: 320px;">
+    <lui-textarea
+      label="Observações"
+      placeholder="Escreva suas observações..."
+      size="lg"
+      error
+      error-text="Campo obrigatório."
+    ></lui-textarea>
+  </div>
+`;
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...Textarea.args,
-  label: 'Comentário',
-  value: 'Conteúdo somente leitura.',
-  hint: '',
-  optional: false,
-  disabled: true,
-};
+export const Disabled = () => `
+  <div style="width: 320px;">
+    <lui-textarea
+      label="Comentário"
+      value="Conteúdo somente leitura."
+      size="lg"
+      disabled
+    ></lui-textarea>
+  </div>
+`;
 
-export const NoResize = Template.bind({});
-NoResize.args = {
-  ...Textarea.args,
-  label: 'Mensagem',
-  placeholder: 'Sua mensagem...',
-  resize: 'none',
-  hint: 'Tamanho fixo.',
-  optional: false,
-};
+export const NoResize = () => `
+  <div style="width: 320px;">
+    <lui-textarea
+      label="Mensagem"
+      placeholder="Sua mensagem..."
+      size="lg"
+      resize="none"
+      hint="Tamanho fixo."
+    ></lui-textarea>
+  </div>
+`;
 NoResize.storyName = 'Resize: None';
+
+export const Required = () => `
+  <div style="width: 320px;">
+    <lui-textarea
+      name="message"
+      label="Mensagem"
+      placeholder="Escreva sua mensagem..."
+      size="lg"
+      required
+      hint="Campo obrigatório."
+      error-text="Mensagem é obrigatória."
+    ></lui-textarea>
+  </div>
+`;
+Required.parameters = {
+  docs: {
+    description: {
+      story:
+        'Com `required`, o campo bloqueia a submissão do form quando vazio via `ElementInternals.setValidity()`.',
+    },
+  },
+};
+
+export const FormIntegration = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'max-width: 360px; display: flex; flex-direction: column; gap: 24px;';
+  container.innerHTML = `
+    <form id="textarea-demo-form" style="display: flex; flex-direction: column; gap: 16px;">
+      <lui-textarea
+        name="message"
+        label="Mensagem"
+        placeholder="Escreva sua mensagem..."
+        size="lg"
+        required
+        maxlength="300"
+        error-text="Mensagem é obrigatória."
+      ></lui-textarea>
+      <div style="display: flex; gap: 8px; justify-content: flex-end;">
+        <lui-button type="reset" variant="secondary" size="md">Limpar</lui-button>
+        <lui-button type="submit" variant="primary" size="md">Enviar</lui-button>
+      </div>
+    </form>
+    <p id="textarea-demo-feedback" style="font-size: 13px; min-height: 18px;"></p>
+  `;
+
+  const form = container.querySelector('#textarea-demo-form');
+  const feedback = container.querySelector('#textarea-demo-feedback');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    feedback.style.color = 'green';
+    feedback.textContent = `✓ Enviado: "${data.get('message')}"`;
+  });
+
+  form.addEventListener('reset', () => {
+    feedback.textContent = '';
+  });
+
+  return container;
+};
+FormIntegration.storyName = 'Form Integration';
+FormIntegration.parameters = {
+  docs: {
+    description: {
+      story:
+        'O `lui-textarea` é form-associated — seu valor é capturado via `FormData` através do atributo `name`. `required` bloqueia a submissão quando o campo está vazio.',
+    },
+  },
+};

--- a/packages/lets-ui-components/src/components/textarea/textarea.ts
+++ b/packages/lets-ui-components/src/components/textarea/textarea.ts
@@ -14,7 +14,6 @@ export class LuiTextarea extends LitElement {
   @property() size = 'lg';
   @property() name = '';
   @property() value = '';
-  @property() form = '';
   @property({ type: Boolean }) disabled = false;
   @property({ type: Boolean }) required = false;
   @property({ type: Boolean }) optional = false;

--- a/packages/lets-ui-components/src/components/textarea/textarea.ts
+++ b/packages/lets-ui-components/src/components/textarea/textarea.ts
@@ -1,15 +1,22 @@
-import { LitElement, html, unsafeCSS } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { LitElement, html, unsafeCSS, PropertyValues } from 'lit';
+import { property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './textarea.scss?inline';
 
 export class LuiTextarea extends LitElement {
   static styles = unsafeCSS(styles);
+  static formAssociated = true;
+
+  private _internals: ElementInternals;
 
   @property() label = '';
   @property() placeholder = '';
   @property() size = 'lg';
+  @property() name = '';
   @property() value = '';
+  @property() form = '';
   @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean }) required = false;
   @property({ type: Boolean }) optional = false;
   @property({ attribute: 'optional-text' }) optionalText = '(opcional)';
   @property() hint = '';
@@ -23,11 +30,45 @@ export class LuiTextarea extends LitElement {
 
   @state() private _charCount = 0;
 
+  @query('.textarea-field__input') private _textareaEl!: HTMLTextAreaElement;
+
   private _baseId: string;
 
   constructor() {
     super();
     this._baseId = `lui-textarea-${Math.random().toString(36).slice(2, 9)}`;
+    this._internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._internals.setFormValue(this.value || null);
+    this.addEventListener('invalid', () => {
+      this.error = true;
+    });
+  }
+
+  protected firstUpdated() {
+    this._syncFormValue();
+  }
+
+  protected updated(changed: PropertyValues) {
+    if (changed.has('value')) {
+      this._syncFormValue();
+    }
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+  }
+
+  formResetCallback() {
+    this.value = '';
+    this._charCount = 0;
+    this.error = false;
+    if (this._textareaEl) this._textareaEl.value = '';
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {
@@ -53,15 +94,33 @@ export class LuiTextarea extends LitElement {
         : 'vertical';
   }
 
-  private _handleInput(e: Event) {
-    const textarea = e.target as HTMLTextAreaElement;
-    this._charCount = textarea.value.length;
-    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  private _syncFormValue() {
+    const val = this._textareaEl?.value ?? '';
+    this._internals.setFormValue(val || null);
+    if (this.required && !val.trim()) {
+      this._internals.setValidity(
+        { valueMissing: true },
+        this.errorText,
+        this._textareaEl
+      );
+    } else {
+      this._internals.setValidity({});
+    }
   }
 
-  private _handleChange() {
+  private _handleInput = (e: Event) => {
+    const textarea = e.target as HTMLTextAreaElement;
+    this._charCount = textarea.value.length;
+    this.error = false;
+    this._syncFormValue();
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  };
+
+  private _handleChange = () => {
+    this.error = false;
+    this._syncFormValue();
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
-  }
+  };
 
   render() {
     const ariaLabel = this.ariaLabel || this.label || 'Textarea';
@@ -103,6 +162,7 @@ export class LuiTextarea extends LitElement {
           <textarea
             class="textarea-field__input"
             id="${this._baseId}-input"
+            name="${ifDefined(this.name || undefined)}"
             aria-label="${ariaLabel}"
             aria-describedby="${describedBy}"
             placeholder="${this.placeholder}"
@@ -110,6 +170,7 @@ export class LuiTextarea extends LitElement {
             style="resize: ${this._resizeValue};"
             maxlength="${maxLen !== null ? maxLen : ''}"
             ?disabled="${this.disabled}"
+            ?required="${this.required}"
             ?aria-disabled="${this.disabled}"
             @input="${this._handleInput}"
             @change="${this._handleChange}"

--- a/packages/lets-ui-components/src/components/textarea/textarea.ts
+++ b/packages/lets-ui-components/src/components/textarea/textarea.ts
@@ -66,8 +66,7 @@ export class LuiTextarea extends LitElement {
     this._charCount = 0;
     this.error = false;
     if (this._textareaEl) this._textareaEl.value = '';
-    this._internals.setFormValue(null);
-    this._internals.setValidity({});
+    this._syncFormValue();
   }
 
   get _size(): 'xl' | 'lg' | 'md' | 'sm' {

--- a/packages/lets-ui-components/src/index.ts
+++ b/packages/lets-ui-components/src/index.ts
@@ -16,6 +16,7 @@ import { LuiButton } from './components/button/button.js';
 import { LuiCard } from './components/card/card.js';
 import { LuiCheckbox } from './components/checkbox/checkbox.js';
 import { LuiRadio } from './components/radio/radio.js';
+import { LuiRadioGroup } from './components/radio-group/radio-group.js';
 import { LuiSwitch } from './components/switch/switch.js';
 import { LuiIconButton } from './components/icon-button/icon-button.js';
 import { LuiInput } from './components/input/input.js';
@@ -50,6 +51,7 @@ define('lui-button', LuiButton);
 define('lui-card', LuiCard);
 define('lui-checkbox', LuiCheckbox);
 define('lui-radio', LuiRadio);
+define('lui-radio-group', LuiRadioGroup);
 define('lui-switch', LuiSwitch);
 define('lui-icon-button', LuiIconButton);
 define('lui-input', LuiInput);
@@ -80,6 +82,7 @@ export {
   LuiCard,
   LuiCheckbox,
   LuiRadio,
+  LuiRadioGroup,
   LuiSwitch,
   LuiIconButton,
   LuiInput,

--- a/packages/styles/src/components/_checkbox.scss
+++ b/packages/styles/src/components/_checkbox.scss
@@ -9,6 +9,18 @@ $size: (
   md: 16,
 );
 
+.checkbox-field {
+  display: inline-flex;
+  flex-direction: column;
+  gap: fluid(4);
+
+  &__message {
+    @include font-scale(body--md);
+
+    color: text(error);
+  }
+}
+
 .checkbox,
 input[type='checkbox'] {
   @include selection.wrapper;

--- a/packages/styles/src/components/_radio-group.scss
+++ b/packages/styles/src/components/_radio-group.scss
@@ -1,0 +1,59 @@
+@use '../utilities/functions' as *;
+@use '../utilities/mixins' as *;
+
+$size: (
+  lg: body--lg,
+  md: body--md,
+);
+
+.radio-group {
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-inline-size: 0;
+  display: flex;
+  flex-direction: column;
+
+  &__legend {
+    color: text(body);
+    font-weight: 500;
+    padding: 0;
+  }
+
+  @each $key, $scale in $size {
+    &--#{$key} .radio-group__legend {
+      @include font-scale($scale);
+    }
+  }
+
+  &__hint {
+    @include font-scale(body--md);
+
+    color: text(caption);
+    margin: fluid(4) 0 0;
+    padding: 0;
+  }
+
+  &__options {
+    display: flex;
+    flex-direction: column;
+    gap: fluid(8);
+  }
+
+  &__legend ~ &__options,
+  &__hint ~ &__options {
+    margin-top: fluid(8);
+  }
+
+  &__message {
+    @include font-scale(body--md);
+
+    color: text(caption);
+    margin: fluid(8) 0 0;
+    padding: 0;
+  }
+
+  &--error &__message {
+    color: text(error);
+  }
+}

--- a/packages/styles/src/components/_radio.scss
+++ b/packages/styles/src/components/_radio.scss
@@ -8,10 +8,12 @@ $sizes: (
   lg: (
     outer: 24,
     dot: 10,
+    label: body--lg,
   ),
   md: (
     outer: 16,
     dot: 6,
+    label: body--md,
   ),
 );
 
@@ -24,14 +26,21 @@ input[type='radio'] {
   @each $key, $values in $sizes {
     $outer: map.get($values, outer);
     $dot: map.get($values, dot);
+    $label: map.get($values, label);
 
-    &--#{$key} input[type='radio'] {
-      width: fixed($outer);
-      height: fixed($outer);
+    &--#{$key} {
+      input[type='radio'] {
+        width: fixed($outer);
+        height: fixed($outer);
 
-      &:checked::after {
-        width: #{$dot}px;
-        height: #{$dot}px;
+        &:checked::after {
+          width: #{$dot}px;
+          height: #{$dot}px;
+        }
+      }
+
+      slot {
+        @include font-scale($label);
       }
     }
   }

--- a/packages/styles/src/components/_switch.scss
+++ b/packages/styles/src/components/_switch.scss
@@ -20,6 +20,18 @@ $sizes: (
   ),
 );
 
+.switch-field {
+  display: inline-flex;
+  flex-direction: column;
+  gap: fluid(4);
+
+  &__message {
+    @include font-scale(body--md);
+
+    color: text(error);
+  }
+}
+
 .switch {
   @include selection.wrapper;
 

--- a/playground/src/pages/forms.astro
+++ b/playground/src/pages/forms.astro
@@ -1,0 +1,590 @@
+---
+import '@lets-ui/tokens';
+import '@lets-ui/styles';
+---
+
+<!doctype html>
+<html lang="pt-BR" data-theme="light" data-brand="lets-ui">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Form Integration — Let's UI Playground</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: var(--lui-brand-typography-font-family-body);
+        background: var(--lui-color-neutral-background-surface);
+        color: var(--lui-color-neutral-text-body);
+        margin: 0;
+        padding: 40px 24px 80px;
+      }
+
+      .page-header {
+        margin-bottom: 48px;
+      }
+
+      .page-header h1 {
+        font-size: 1.5rem;
+        font-weight: 600;
+        margin: 0 0 8px;
+      }
+
+      .page-header p {
+        font-size: 0.875rem;
+        color: var(--lui-color-neutral-text-subtle);
+        margin: 0;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 40px;
+        max-width: 1100px;
+      }
+
+      @media (max-width: 768px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .card {
+        background: var(--lui-color-neutral-background-default);
+        border: 1px solid var(--lui-color-neutral-border-subtle);
+        border-radius: 12px;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+
+      .card h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        margin: 0 0 4px;
+      }
+
+      .card p.description {
+        font-size: 0.8125rem;
+        color: var(--lui-color-neutral-text-subtle);
+        margin: 0 0 4px;
+      }
+
+      .form-body {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .form-row {
+        display: flex;
+        gap: 12px;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+      }
+
+      .radio-group {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .radio-group legend {
+        font-size: 0.875rem;
+        font-weight: 500;
+        margin-bottom: 8px;
+        color: var(--lui-color-neutral-text-body);
+      }
+
+      .switch-group {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .output {
+        background: var(--lui-color-neutral-background-subtle);
+        border: 1px solid var(--lui-color-neutral-border-subtle);
+        border-radius: 8px;
+        padding: 12px 16px;
+        font-size: 0.8125rem;
+        font-family: monospace;
+        min-height: 48px;
+        white-space: pre-wrap;
+        color: var(--lui-color-neutral-text-body);
+      }
+
+      .output.success {
+        border-color: var(--lui-color-success-border-default);
+        color: var(--lui-color-success-text-body);
+      }
+
+      .divider {
+        border: none;
+        border-top: 1px solid var(--lui-color-neutral-border-subtle);
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page-header">
+      <h1>Form Integration</h1>
+      <p>
+        Testa a integração de todos os componentes de formulário com <code
+          >FormData</code
+        >, reset e validação nativa.
+      </p>
+    </div>
+
+    <div class="layout">
+      <!-- ── Input + Textarea ───────────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Input &amp; Textarea</h2>
+          <p class="description">
+            Campos de texto com <code>name</code>, <code>required</code> e reset.
+          </p>
+        </div>
+        <form class="form-body" id="form-text">
+          <lui-input
+            name="name"
+            label="Nome"
+            placeholder="Digite seu nome"
+            size="lg"
+            required
+            error-text="Nome é obrigatório."></lui-input>
+          <lui-input
+            name="email"
+            label="E-mail"
+            placeholder="seu@email.com"
+            size="lg"
+            required
+            error-text="E-mail é obrigatório."></lui-input>
+          <lui-textarea
+            name="message"
+            label="Mensagem"
+            placeholder="Escreva sua mensagem..."
+            size="lg"
+            maxlength="300"
+            required
+            error-text="Mensagem é obrigatória."></lui-textarea>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Enviar</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-text">Aguardando submissão...</div>
+      </div>
+
+      <!-- ── Select ─────────────────────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Select</h2>
+          <p class="description">
+            Select com <code>name</code>, <code>required</code> e múltiplas opções.
+          </p>
+        </div>
+        <form class="form-body" id="form-select">
+          <lui-native-select
+            name="role"
+            label="Função"
+            placeholder="Selecione sua função"
+            options="Design,Engenharia,Produto,Marketing,Dados"
+            size="lg"
+            required
+            error-text="Selecione uma função."></lui-native-select>
+          <lui-native-select
+            name="seniority"
+            label="Senioridade"
+            placeholder="Selecione a senioridade"
+            options="Júnior,Pleno,Sênior,Staff,Principal"
+            size="lg"
+            required
+            error-text="Selecione a senioridade."></lui-native-select>
+          <lui-native-select
+            name="team"
+            label="Time (opcional)"
+            placeholder="Selecione o time"
+            options="Plataforma,Growth,Core,Infra"
+            size="lg"
+            optional></lui-native-select>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Salvar</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-select">Aguardando submissão...</div>
+      </div>
+
+      <!-- ── Checkbox ───────────────────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Checkbox</h2>
+          <p class="description">
+            Múltiplos checkboxes com <code>name</code>/<code>value</code> distintos
+            e <code>required</code>.
+          </p>
+        </div>
+        <form class="form-body" id="form-checkbox">
+          <lui-checkbox
+            name="newsletter"
+            value="subscribed"
+            label="Quero receber novidades por e-mail"
+            size="lg"></lui-checkbox>
+          <lui-checkbox
+            name="updates"
+            value="enabled"
+            label="Notificar sobre atualizações do produto"
+            size="lg"></lui-checkbox>
+          <lui-checkbox
+            name="terms"
+            value="accepted"
+            label="Li e aceito os termos de uso"
+            required
+            error-text="Você precisa aceitar os termos para continuar."
+            size="lg"></lui-checkbox>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Cadastrar</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-checkbox">Aguardando submissão...</div>
+      </div>
+
+      <!-- ── Radio ──────────────────────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Radio Group</h2>
+          <p class="description">
+            Grupos de radio com <code>lui-radio-group</code>: <code>name</code>,
+            <code>required</code> e <code>error-text</code> definidos uma vez no grupo.
+          </p>
+        </div>
+        <form class="form-body" id="form-radio">
+          <lui-radio-group
+            name="plan"
+            label="Plano"
+            required
+            error-text="Selecione um plano.">
+            <lui-radio value="free" label="Free — até 3 projetos" size="lg"></lui-radio>
+            <lui-radio value="pro" label="Pro — projetos ilimitados" size="lg"></lui-radio>
+            <lui-radio value="enterprise" label="Enterprise — sob consulta" size="lg"></lui-radio>
+          </lui-radio-group>
+          <lui-radio-group
+            name="billing"
+            label="Ciclo de cobrança"
+            required
+            error-text="Selecione o ciclo de cobrança.">
+            <lui-radio value="monthly" label="Mensal" size="lg"></lui-radio>
+            <lui-radio value="yearly" label="Anual (2 meses grátis)" size="lg"></lui-radio>
+          </lui-radio-group>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Continuar</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-radio">Aguardando submissão...</div>
+      </div>
+
+      <!-- ── Switch ─────────────────────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Switch</h2>
+          <p class="description">
+            Switches com <code>name</code>/<code>value</code>; campos omitidos
+            quando desativados.
+          </p>
+        </div>
+        <form class="form-body" id="form-switch">
+          <div class="switch-group">
+            <lui-switch
+              name="notifications"
+              value="enabled"
+              label="Receber notificações"
+              checked
+              size="lg"></lui-switch>
+            <lui-switch
+              name="darkmode"
+              value="enabled"
+              label="Modo escuro"
+              size="lg"></lui-switch>
+            <lui-switch
+              name="analytics"
+              value="enabled"
+              label="Compartilhar dados de uso"
+              checked
+              size="lg"></lui-switch>
+            <lui-switch
+              name="marketing"
+              value="enabled"
+              label="Comunicações de marketing"
+              size="lg"></lui-switch>
+          </div>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Restaurar padrões</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Salvar preferências</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-switch">Aguardando submissão...</div>
+      </div>
+
+      <!-- ── Validação visual (invalid event) ─────────────── -->
+      <div class="card">
+        <div>
+          <h2>Validação visual</h2>
+          <p class="description">
+            Testa que o evento <code>invalid</code> ativa o estado de erro com <code
+              >error-text</code
+            > em todos os campos.
+          </p>
+        </div>
+        <form class="form-body" id="form-validation">
+          <lui-input
+            name="val-name"
+            label="Nome"
+            placeholder="Deixe em branco e tente enviar"
+            required
+            error-text="Nome é obrigatório."
+            size="lg"></lui-input>
+          <lui-native-select
+            name="val-role"
+            label="Função"
+            placeholder="Não selecione nada"
+            options="Design,Engenharia,Produto"
+            required
+            error-text="Selecione uma função."
+            size="lg"></lui-native-select>
+          <lui-textarea
+            name="val-bio"
+            label="Bio"
+            placeholder="Deixe em branco e tente enviar"
+            required
+            error-text="Bio é obrigatória."
+            size="lg"></lui-textarea>
+          <lui-checkbox
+            name="val-terms"
+            value="accepted"
+            label="Aceito os termos"
+            required
+            error-text="Aceite os termos para continuar."
+            size="lg"></lui-checkbox>
+          <lui-radio-group
+            name="val-profile"
+            label="Perfil (obrigatório)"
+            required
+            error-text="Selecione um perfil.">
+            <lui-radio value="designer" label="Designer" size="lg"></lui-radio>
+            <lui-radio value="developer" label="Desenvolvedor" size="lg"></lui-radio>
+          </lui-radio-group>
+          <lui-switch
+            name="val-agree"
+            value="yes"
+            label="Concordo com a política de privacidade"
+            required
+            error-text="É necessário concordar para continuar."
+            size="lg"></lui-switch>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar erros</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Validar</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-validation">
+          Clique em "Validar" sem preencher os campos para ver os erros.
+        </div>
+      </div>
+
+      <!-- ── Prefill programático ──────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Prefill programático</h2>
+          <p class="description">
+            Verifica que valores definidos via JavaScript sincronizam
+            corretamente com o <code>FormData</code>. Os campos são preenchidos
+            600ms após o carregamento.
+          </p>
+        </div>
+        <form class="form-body" id="form-prefill">
+          <lui-input
+            name="prefill-name"
+            label="Nome"
+            placeholder="Será preenchido via JS..."
+            size="lg"></lui-input>
+          <lui-native-select
+            name="prefill-role"
+            label="Função"
+            placeholder="Será selecionado via JS..."
+            options="Design,Engenharia,Produto,Marketing"
+            size="lg"></lui-native-select>
+          <lui-checkbox
+            name="prefill-newsletter"
+            value="yes"
+            label="Quero receber novidades"
+            size="lg"></lui-checkbox>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Verificar FormData</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-prefill">
+          Aguardando prefill via JS...
+        </div>
+      </div>
+
+      <!-- ── Mixed Form ─────────────────────────────────────── -->
+      <div class="card">
+        <div>
+          <h2>Formulário completo</h2>
+          <p class="description">
+            Todos os componentes juntos em um único form.
+          </p>
+        </div>
+        <form class="form-body" id="form-mixed">
+          <lui-input
+            name="fullname"
+            label="Nome completo"
+            placeholder="Seu nome"
+            size="lg"
+            required
+            error-text="Nome é obrigatório."></lui-input>
+          <lui-native-select
+            name="country"
+            label="País"
+            placeholder="Selecione o país"
+            options="Brasil,Portugal,Espanha,Estados Unidos"
+            size="lg"
+            required
+            error-text="Selecione um país."></lui-native-select>
+          <lui-radio-group
+            name="profile"
+            label="Perfil"
+            required
+            error-text="Selecione um perfil.">
+            <lui-radio value="designer" label="Designer" size="lg"></lui-radio>
+            <lui-radio value="developer" label="Desenvolvedor" size="lg"></lui-radio>
+            <lui-radio value="pm" label="Product Manager" size="lg"></lui-radio>
+          </lui-radio-group>
+          <lui-textarea
+            name="bio"
+            label="Bio"
+            placeholder="Conte um pouco sobre você..."
+            size="lg"
+            maxlength="200"></lui-textarea>
+          <lui-switch
+            name="public"
+            value="yes"
+            label="Perfil público"
+            checked
+            size="lg"></lui-switch>
+          <lui-checkbox
+            name="terms"
+            value="accepted"
+            label="Li e aceito os termos de uso"
+            required
+            size="lg"></lui-checkbox>
+          <div class="form-row">
+            <lui-button type="reset" variant="secondary" size="md"
+              >Limpar</lui-button
+            >
+            <lui-button type="submit" variant="primary" size="md"
+              >Criar perfil</lui-button
+            >
+          </div>
+        </form>
+        <hr class="divider" />
+        <div class="output" id="output-mixed">Aguardando submissão...</div>
+      </div>
+    </div>
+
+    <script>
+      import '@lets-ui/components';
+    </script>
+
+    <script type="module">
+      function formatFormData(data) {
+        const entries = [...data.entries()];
+        if (entries.length === 0) return '(nenhum campo submetido)';
+        return entries.map(([k, v]) => `${k}: "${v}"`).join('\n');
+      }
+
+      function bindForm(formId, outputId) {
+        const form = document.getElementById(formId);
+        const output = document.getElementById(outputId);
+
+        form.addEventListener('submit', (e) => {
+          e.preventDefault();
+          const data = new FormData(e.target);
+          output.className = 'output success';
+          output.textContent = '✓ Submetido:\n' + formatFormData(data);
+        });
+
+        form.addEventListener('reset', () => {
+          output.className = 'output';
+          output.textContent = 'Aguardando submissão...';
+        });
+      }
+
+      bindForm('form-text', 'output-text');
+      bindForm('form-select', 'output-select');
+      bindForm('form-checkbox', 'output-checkbox');
+      bindForm('form-radio', 'output-radio');
+      bindForm('form-switch', 'output-switch');
+      bindForm('form-validation', 'output-validation');
+      bindForm('form-prefill', 'output-prefill');
+      bindForm('form-mixed', 'output-mixed');
+
+      // Prefill via JS após 600ms — testa sincronização programática (Gap 1)
+      setTimeout(() => {
+        document.querySelector('lui-input[name="prefill-name"]').value =
+          'Maria Silva';
+        document.querySelector(
+          'lui-native-select[name="prefill-role"]'
+        ).selected = 2;
+        document.querySelector(
+          'lui-checkbox[name="prefill-newsletter"]'
+        ).checked = true;
+        document.getElementById('output-prefill').textContent =
+          'Campos preenchidos via JS. Submeta para verificar o FormData.';
+      }, 600);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Add native form participation via `ElementInternals` (`formAssociated`) to `lui-button`, `lui-checkbox`, `lui-input`, `lui-radio`, `lui-select`, `lui-switch`, and `lui-textarea` — each gains `name`, `form`, and `required` props plus `formDisabledCallback`/`formResetCallback`
- Add `error` and `error-text` props to `lui-checkbox` and `lui-switch` for inline validation messages; `lui-input` and `lui-select` already had them
- New `lui-radio-group` component — wraps `lui-radio` elements under a shared `name` and manages label, hint, required, disabled, error state, and form value via `ElementInternals`
- Extend `lui-button` with `type`, `block`, `loading`, `loading-text`, `autofocus`, `name`, `value`, `form` props and `prefix`/`suffix`/default slots

## Test plan

- [x] All form components participate correctly in a native `<form>` (submit, reset, disabled fieldset)
- [x] `required` validation triggers `invalid` event and shows error message on `lui-checkbox`, `lui-switch`, `lui-input`, `lui-select`, and `lui-radio-group`
- [x] `lui-radio-group` deselects siblings when a radio is selected and submits the correct value
- [x] `lui-button` with `type="submit"` submits the closest form; `type="reset"` resets it
- [x] `lui-button` `loading` state shows spinner, blocks clicks, and reflects `aria-busy="true"`
- [x] `lui-button` `block` prop stretches to full width
- [ ] Storybook stories render without errors for all updated components

🤖 Generated with [Claude Code](https://claude.com/claude-code)