### PR TITLE
feat: extend lui-button and lui-link with new props and slots

### DIFF
--- a/.changeset/tough-apples-agree.md
+++ b/.changeset/tough-apples-agree.md
@@ -1,0 +1,13 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+lui-button: Added block, loading, loading-text, type, and autofocus props; added slot support
+(default, prefix, suffix) for label and icon composition; fixed icon sizing via CSS custom
+property.
+
+lui-link: Added target, rel (auto noopener noreferrer on \_blank), download, hreflang,
+referrerpolicy, external (inline SVG icon), size, disabled, and visited props with full
+anchor attribute coverage.

--- a/packages/lets-ui-components/src/components/button/Button.docs.mdx
+++ b/packages/lets-ui-components/src/components/button/Button.docs.mdx
@@ -10,8 +10,99 @@ Elemento interativo utilizado para executar ações na interface.
 <Canvas of={ButtonStories.Button} />
 <Controls of={ButtonStories.Button} />
 
-## Primary
+## Variantes
+
+### Primary
+
+Ação principal da tela. Use para o CTA mais importante — deve existir apenas um por contexto.
+
 <Canvas of={ButtonStories.Primary} />
 
-## Secondary
+### Secondary
+
+Ação secundária ou complementar. Use ao lado do Primary para oferecer uma alternativa de menor peso visual.
+
 <Canvas of={ButtonStories.Secondary} />
+
+### Neutral
+
+Ação genérica sem conotação semântica. Use para ações utilitárias que não se encaixam em nenhum outro contexto.
+
+<Canvas of={ButtonStories.Neutral} />
+
+### Danger
+
+Ação destrutiva ou irreversível. Use para confirmar exclusões, remoções ou operações de alto risco.
+
+<Canvas of={ButtonStories.Danger} />
+
+### Success
+
+Ação de confirmação positiva. Use para finalizar fluxos como salvar, enviar ou concluir.
+
+<Canvas of={ButtonStories.Success} />
+
+## Icon
+
+<Canvas of={ButtonStories.WithIcon} />
+
+## Block
+
+O atributo `block` faz o botão ocupar toda a largura disponível do container pai.
+
+<Canvas of={ButtonStories.Block} />
+
+## Disabled
+
+O atributo `disabled` desabilita o botão e previne interações.
+
+<Canvas of={ButtonStories.Disabled} />
+
+## Label
+
+<Canvas of={ButtonStories.Label} />
+
+## Loading
+
+O atributo `loading` exibe um spinner e bloqueia interações enquanto uma operação está em andamento.
+O botão não fica opaco: permanece visualmente ativo, indicando progresso.
+
+<Canvas of={ButtonStories.Loading} />
+
+### Loading com texto alternativo
+
+O atributo `loading-text` substitui o label exibido enquanto `loading` estiver ativo.
+Útil para comunicar o estado ao usuário sem alterar o label original.
+
+<Canvas of={ButtonStories.LoadingWithText} />
+
+### Loading em todas as variantes
+
+<Canvas of={ButtonStories.AllVariantsLoading} />
+
+## Autofocus
+
+Use `autofocus` para mover o foco do teclado automaticamente para o botão quando o contexto é renderizado.
+O caso de uso mais comum é a ação primária de um diálogo ou modal: ao abrir, o foco já está no botão correto,
+permitindo que o usuário confirme a ação com Enter sem precisar navegar.
+
+**Evite usar em páginas inteiras.** Receber foco automaticamente no meio do conteúdo desorientaletores de tela e
+usuários de teclado, que esperam começar a navegação pelo topo. Reserve para contextos isolados e transitórios,
+como modais, drawers e alertas de confirmação.
+
+<Canvas of={ButtonStories.Autofocus} />
+
+## Atributos
+
+| Atributo       | Tipo      | Padrão      | Descrição                                                             |
+| -------------- | --------- | ----------- | --------------------------------------------------------------------- |
+| `label`        | `string`  | `''`        | Texto exibido no botão                                                |
+| `variant`      | `string`  | `'primary'` | Estilo visual: `primary`, `secondary`, `neutral`, `danger`, `success` |
+| `size`         | `string`  | `'lg'`      | Tamanho: `lg`, `md`                                                   |
+| `type`         | `string`  | `'button'`  | Tipo HTML: `button`, `submit`, `reset`                                |
+| `disabled`     | `boolean` | `false`     | Desabilita o botão e previne interações                               |
+| `autofocus`    | `boolean` | `false`     | Move o foco para o botão automaticamente ao renderizar o contexto     |
+| `block`        | `boolean` | `false`     | Torna o botão full-width dentro do seu container                      |
+| `loading`      | `boolean` | `false`     | Exibe spinner e bloqueia interações; não aplica opacidade de disabled |
+| `loading-text` | `string`  | `''`        | Texto alternativo exibido enquanto `loading` estiver ativo            |
+| `aria-label`   | `string`  | `''`        | Label acessível sobrescrevendo o derivado do `label`                  |

--- a/packages/lets-ui-components/src/components/button/Button.stories.js
+++ b/packages/lets-ui-components/src/components/button/Button.stories.js
@@ -5,46 +5,170 @@ import '../../index.js';
 export default {
   title: 'Actionable/Button',
   argTypes: {
-    label: { control: 'text' },
+    label: {
+      control: 'text',
+    },
     variant: {
       control: { type: 'select' },
-      options: ['primary', 'secondary', 'danger', 'success'],
+      options: ['primary', 'secondary', 'neutral', 'danger', 'success'],
+      table: { defaultValue: { summary: 'primary' } },
     },
     size: {
       control: { type: 'select' },
       options: ['lg', 'md'],
+      table: { defaultValue: { summary: 'lg' } },
     },
-    disabled: { control: 'boolean' },
+    disabled: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    block: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    loading: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['button', 'submit', 'reset'],
+      table: { defaultValue: { summary: 'button' } },
+    },
+    autofocus: {
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    'loading-text': {
+      control: 'text',
+    },
+    'aria-label': {
+      control: 'text',
+    },
   },
 };
 
-const Template = ({ label, variant, size, disabled }) =>
-  `<lui-button
-    label="${label}"
-    variant="${variant}"
-    size="${size}"
-    ${disabled ? 'disabled' : ''}
-  ></lui-button>`;
+const Template = ({
+  label,
+  variant,
+  size,
+  type,
+  autofocus,
+  disabled,
+  block,
+  loading,
+  'loading-text': loadingText,
+  'aria-label': ariaLabel,
+}) => {
+  const attrs = [
+    `variant="${variant}"`,
+    `size="${size}"`,
+    type !== 'button' && `type="${type}"`,
+    autofocus && 'autofocus',
+    disabled && 'disabled',
+    block && 'block',
+    loading && 'loading',
+    loadingText && `loading-text="${loadingText}"`,
+    ariaLabel && `aria-label="${ariaLabel}"`,
+  ]
+    .filter(Boolean)
+    .join('\n  ');
+
+  return `<lui-button\n  ${attrs}\n>\n  ${label}\n</lui-button>`;
+};
 
 export const Button = Template.bind({});
 Button.args = {
   label: 'Botão',
+  'aria-label': '',
   variant: 'primary',
   size: 'lg',
+  type: 'button',
+  block: false,
+  autofocus: false,
   disabled: false,
+  loading: false,
+  'loading-text': '',
 };
 
 export const Primary = () =>
-  `<lui-button variant="primary" size="lg" label="Primary Button"></lui-button>`;
+  `<lui-button variant="primary" size="lg" label="Primary"></lui-button>`;
 
 export const Secondary = () =>
-  `<lui-button variant="secondary" size="lg" label="Secondary Button"></lui-button>`;
+  `<lui-button variant="secondary" size="lg" label="Secondary"></lui-button>`;
+
+export const Neutral = () =>
+  `<lui-button variant="neutral" size="lg" label="Neutral"></lui-button>`;
 
 export const Danger = () =>
-  `<lui-button variant="danger" size="lg" label="Danger Button"></lui-button>`;
+  `<lui-button variant="danger" size="lg" label="Danger"></lui-button>`;
 
 export const Success = () =>
-  `<lui-button variant="success" size="lg" label="Success Button"></lui-button>`;
+  `<lui-button variant="success" size="lg" label="Success"></lui-button>`;
 
 export const Disabled = () =>
-  `<lui-button variant="primary" size="lg" label="Disabled Button" disabled></lui-button>`;
+  `<lui-button variant="primary" size="lg" label="Disabled" disabled></lui-button>`;
+
+export const Block = () =>
+  `<div style="width: 320px; padding: 16px; border: 1px dashed #ccc; border-radius: 8px;">
+    <lui-button variant="primary" size="lg" label="Block Button" block></lui-button>
+  </div>`;
+
+export const Loading = () =>
+  `<lui-button variant="primary" size="lg" label="Salvar" loading></lui-button>`;
+
+export const LoadingWithText = () =>
+  `<lui-button variant="primary" size="lg" label="Salvar" loading loading-text="Salvando..."></lui-button>`;
+
+export const AllVariantsLoading = () =>
+  `<div style="display: flex; gap: 12px; flex-wrap: wrap;">
+    <lui-button variant="primary" size="lg" label="Primary" loading></lui-button>
+    <lui-button variant="secondary" size="lg" label="Secondary" loading></lui-button>
+    <lui-button variant="neutral" size="lg" label="Neutral" loading></lui-button>
+    <lui-button variant="danger" size="lg" label="Danger" loading></lui-button>
+    <lui-button variant="success" size="lg" label="Success" loading></lui-button>
+  </div>`;
+
+export const Label = () =>
+  `<div style="display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
+    <lui-button variant="primary" size="lg" label="Label via atributo"></lui-button>
+  </div>`;
+Label.parameters = {
+  docs: {
+    description: {
+      story:
+        'O texto pode ser passado via atributo `label` ou como conteúdo do slot padrão. Quando o slot é preenchido, ele tem precedência na exibição. O `label` também serve como fallback de `aria-label` quando nenhum texto acessível explícito é fornecido.',
+    },
+  },
+};
+
+const prefixIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true" slot="prefix"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2M8 12l4 4 4-4M12 4v12"/></svg>`;
+const suffixIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true" slot="suffix"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M13 6l6 6-6 6"/></svg>`;
+
+export const WithIcon = () =>
+  `<div style="display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
+    <lui-button variant="primary" size="lg">${prefixIcon}Baixar</lui-button>
+    <lui-button variant="secondary" size="md">Próximo${suffixIcon}</lui-button>
+  </div>`;
+WithIcon.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use `slot="prefix"` para ícones antes do label e `slot="suffix"` para ícones após. Os ícones herdam `currentColor` e escalam com o tamanho de fonte do botão via `1em`.',
+    },
+  },
+};
+
+export const Autofocus = () =>
+  `<div style="display: flex; gap: 12px; align-items: center;">
+    <lui-button variant="secondary" size="lg">Cancelar</lui-button>
+    <lui-button variant="primary" size="lg" autofocus>Confirmar</lui-button>
+  </div>`;
+Autofocus.parameters = {
+  docs: {
+    description: {
+      story:
+        'O botão com `autofocus` recebe foco automaticamente quando o contexto é carregado. Neste preview, o botão "Confirmar" já está focado ao abrir a story.',
+    },
+  },
+};

--- a/packages/lets-ui-components/src/components/button/button.scss
+++ b/packages/lets-ui-components/src/components/button/button.scss
@@ -2,4 +2,27 @@
 
 :host {
   display: inline-flex;
+
+  --lui-btn-icon-size: calc(var(--lui-brand-typography-font-size-1xs) * 1.5);
+}
+
+:host([size='md']) {
+  --lui-btn-icon-size: calc(var(--lui-brand-typography-font-size-2xs) * 1.5);
+}
+
+:host([block]) {
+  display: block;
+
+  button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+::slotted([slot='prefix']),
+::slotted([slot='suffix']) {
+  display: flex;
+  width: var(--lui-btn-icon-size);
+  height: var(--lui-btn-icon-size);
+  flex-shrink: 0;
 }

--- a/packages/lets-ui-components/src/components/button/button.ts
+++ b/packages/lets-ui-components/src/components/button/button.ts
@@ -1,35 +1,60 @@
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, html, svg, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './button.scss?inline';
+
+const spinnerIcon = svg`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" class="btn__spinner">
+  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="56.549" stroke-dashoffset="42.412"/>
+</svg>`;
 
 export class LuiButton extends LitElement {
   static styles = unsafeCSS(styles);
 
   @property() variant = 'primary';
-  @property() size = 'lg';
-  @property({ type: Boolean }) disabled = false;
+  @property({ reflect: true }) size = 'lg';
+  @property() type: 'button' | 'submit' | 'reset' = 'button';
+  @property({ type: Boolean }) autofocus = false;
+  @property({ type: Boolean, reflect: true }) disabled = false;
+  @property({ type: Boolean, reflect: true }) block = false;
+  @property({ type: Boolean }) loading = false;
+  @property({ attribute: 'loading-text' }) loadingText = '';
   @property() label = '';
   @property({ attribute: 'aria-label' }) ariaLabel = '';
 
-  get _size(): 'xl' | 'lg' | 'md' | 'sm' {
-    const s = this.size;
-    return (['xl', 'lg', 'md', 'sm'] as const).includes(
-      s as 'xl' | 'lg' | 'md' | 'sm'
-    )
-      ? (s as 'xl' | 'lg' | 'md' | 'sm')
-      : 'lg';
+  get _size(): 'lg' | 'md' {
+    return this.size === 'md' ? 'md' : 'lg';
+  }
+
+  private get _classes(): string {
+    return [
+      'btn',
+      `btn--${this.variant}`,
+      `btn--${this._size}`,
+      this.loading && 'btn--loading',
+    ]
+      .filter(Boolean)
+      .join(' ');
   }
 
   render() {
-    const ariaLabel = this.ariaLabel || this.label || 'Button';
+    const displayLabel =
+      this.loading && this.loadingText ? this.loadingText : this.label;
+    const isDisabled = this.disabled || this.loading;
+
     return html`
       <button
-        class="btn btn--${this.variant} btn--${this._size}"
-        aria-label="${ariaLabel}"
+        class="${this._classes}"
+        type="${this.type}"
+        ?autofocus="${this.autofocus}"
+        aria-label="${ifDefined(this.ariaLabel || displayLabel || undefined)}"
         ?disabled="${this.disabled}"
-        ?aria-disabled="${this.disabled}"
+        aria-disabled="${isDisabled ? 'true' : 'false'}"
+        aria-busy="${ifDefined(this.loading ? 'true' : undefined)}"
       >
-        ${this.label}
+        ${this.loading
+          ? html`${spinnerIcon}${displayLabel}`
+          : html`<slot name="prefix"></slot><slot>${this.label}</slot
+              ><slot name="suffix"></slot>`}
       </button>
     `;
   }

--- a/packages/styles/src/components/_button.scss
+++ b/packages/styles/src/components/_button.scss
@@ -45,10 +45,19 @@ $size: (
   ),
 );
 
+@keyframes lui-btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 button {
   &.btn {
     position: relative;
     overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    gap: fluid(8);
     font-weight: weight(regular);
     border: fixed(0);
     outline: fixed(0);
@@ -69,6 +78,18 @@ button {
       cursor: not-allowed;
       opacity: opacity(disabled);
     }
+  }
+
+  &.btn--loading {
+    cursor: wait;
+    pointer-events: none;
+  }
+
+  .btn__spinner {
+    flex-shrink: 0;
+    width: fluid(16);
+    height: fluid(16);
+    animation: lui-btn-spin 0.7s linear infinite;
   }
 
   @each $key, $props in $size {


### PR DESCRIPTION
## Summary

- **`lui-button`:** Added `block`, `loading`, `loading-text`, `type`, and `autofocus` props; added slot support (`default`, `prefix`, `suffix`) for label and icon composition; fixed icon sizing via CSS custom property scaled to line-height
- **`lui-link`:** Added `target`, `rel` (auto `noopener noreferrer` on `_blank`), `download`, `hreflang`, `referrerpolicy`, `external` (inline SVG icon), `size`, `disabled`, and `visited` props with full anchor attribute coverage
- Updated Storybook stories and MDX docs for both components

## Test plan

- [x] `lui-button` renders correctly with `block`, `loading`, and `loading-text` props
- [x] `lui-button` prefix/suffix slots render icons; default slot renders label text
- [x] `lui-button` respects `type` (button/submit/reset) and `autofocus`
- [x] `lui-link` sets `target` and auto-applies `rel="noopener noreferrer"` when `target="_blank"`
- [x] `lui-link` renders external icon when `external` prop is set
- [x] `lui-link` applies correct size styles (`lg`/`md`/`sm`) and `disabled`/`visited` states
- [x] Storybook stories load without errors for both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)