### PR TITLE
docs(storybook): add CSS class usage to all component docs

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,6 +18,8 @@ const preview = {
           'Navigation',
           'Form and options',
           'Content',
+          'Typography',
+          ['Heading', 'Body', 'Shortcut'],
           'Layout',
           'Miscellaneous',
           'Utilities',

--- a/packages/lets-ui-components/src/components/alert/Alert.docs.mdx
+++ b/packages/lets-ui-components/src/components/alert/Alert.docs.mdx
@@ -19,3 +19,27 @@ import * as AlertStories from './Alert.stories';
 
 ## Success
 <Canvas of={AlertStories.Success} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={AlertStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-alert variant="info" title="Título" content="Informação importante"></lui-alert>
+```
+
+### Classe CSS
+
+```html
+<div class="alert alert--info">
+  <div class="alert__content">
+    <div class="alert__text">
+      <p>Informação importante</p>
+    </div>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/alert/Alert.stories.js
+++ b/packages/lets-ui-components/src/components/alert/Alert.stories.js
@@ -54,3 +54,14 @@ export const WithoutActions = () => `
   ></lui-alert>
 `;
 WithoutActions.storyName = 'Without actions';
+
+export const CSSClass = () => `
+  <div class="alert alert--info">
+    <div class="alert__content">
+      <div class="alert__text">
+        <p>Informação importante</p>
+      </div>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/body/Body.docs.mdx
+++ b/packages/lets-ui-components/src/components/body/Body.docs.mdx
@@ -40,3 +40,20 @@ Use `align` com `left`, `center`, `right` ou `justify`.
 
 <Canvas of={BodyStories.WithLineClamp} />
 
+## Classe CSS (sem Web Component)
+
+<Canvas of={BodyStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-body variant="md" color="body" label="Texto de conteúdo."></lui-body>
+```
+
+### Classe CSS
+
+```html
+<p class="body--md">Texto com escala tipográfica body médio.</p>
+```

--- a/packages/lets-ui-components/src/components/body/Body.stories.js
+++ b/packages/lets-ui-components/src/components/body/Body.stories.js
@@ -3,7 +3,7 @@ import '../../../../../packages/styles/dist/letsui.css';
 import '../../index.js';
 
 export default {
-  title: 'Content/Typography/Body',
+  title: 'Typography/Body',
   argTypes: {
     variant: {
       control: { type: 'select' },
@@ -114,3 +114,8 @@ export const WithLineClamp = () => `
     style="max-width: 400px; display: block;"
   ></lui-body>
 `;
+
+export const CSSClass = () => `
+  <p class="body--md">Texto com escala tipográfica body médio.</p>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/box/Box.docs.mdx
+++ b/packages/lets-ui-components/src/components/box/Box.docs.mdx
@@ -129,3 +129,25 @@ Unknown values are passed through as-is, so raw CSS values and `var()` reference
 ## Card
 
 <Canvas of={BoxStories.Card} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={BoxStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-box padding="md" background="neutral/surface" border-radius="md" border-width="1" border-color="neutral/subtle">
+  Conteúdo com padding interno
+</lui-box>
+```
+
+### Classe CSS
+
+```html
+<div class="box box--padding-md">
+  Conteúdo com padding interno
+</div>
+```

--- a/packages/lets-ui-components/src/components/box/Box.stories.js
+++ b/packages/lets-ui-components/src/components/box/Box.stories.js
@@ -249,3 +249,10 @@ export const RawCSSFallback = () => `
   </div>
 `;
 RawCSSFallback.storyName = 'Raw CSS fallback';
+
+export const CSSClass = () => `
+  <div class="box box--padding-md">
+    Conteúdo com padding interno
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/breadcrumb/Breadcrumb.docs.mdx
+++ b/packages/lets-ui-components/src/components/breadcrumb/Breadcrumb.docs.mdx
@@ -7,3 +7,31 @@ import * as BreadcrumbStories from './Breadcrumb.stories';
 
 <Canvas of={BreadcrumbStories.Default} />
 <Controls of={BreadcrumbStories.Default} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={BreadcrumbStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-breadcrumb aria-label="Breadcrumb">
+  <lui-breadcrumb-item href="#">Home</lui-breadcrumb-item>
+  <lui-breadcrumb-item href="#">Categoria</lui-breadcrumb-item>
+  <lui-breadcrumb-item active>Página atual</lui-breadcrumb-item>
+</lui-breadcrumb>
+```
+
+### Classe CSS
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol class="breadcrumb">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Categoria</a></li>
+    <li aria-current="page">Página atual</li>
+  </ol>
+</nav>
+```

--- a/packages/lets-ui-components/src/components/breadcrumb/Breadcrumb.stories.js
+++ b/packages/lets-ui-components/src/components/breadcrumb/Breadcrumb.stories.js
@@ -27,3 +27,14 @@ Default.args = {
   link: '#',
   ariaLabel: 'Breadcrumb',
 };
+
+export const CSSClass = () => `
+  <nav aria-label="Breadcrumb">
+    <ol class="breadcrumb">
+      <li><a href="#">Home</a></li>
+      <li><a href="#">Categoria</a></li>
+      <li aria-current="page">Página atual</li>
+    </ol>
+  </nav>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/button/Button.docs.mdx
+++ b/packages/lets-ui-components/src/components/button/Button.docs.mdx
@@ -118,3 +118,23 @@ como modais, drawers e alertas de confirmação.
 | `loading`      | `boolean` | `false`     | Exibe spinner e bloqueia interações; não aplica opacidade de disabled |
 | `loading-text` | `string`  | `''`        | Texto alternativo exibido enquanto `loading` estiver ativo            |
 | `aria-label`   | `string`  | `''`        | Label acessível sobrescrevendo o derivado do `label`                  |
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={ButtonStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-button variant="primary" size="lg">Confirmar</lui-button>
+<lui-button variant="secondary" size="lg">Cancelar</lui-button>
+```
+
+### Classe CSS
+
+```html
+<button class="btn btn--primary btn--lg">Confirmar</button>
+<button class="btn btn--secondary btn--lg">Cancelar</button>
+```

--- a/packages/lets-ui-components/src/components/button/Button.stories.js
+++ b/packages/lets-ui-components/src/components/button/Button.stories.js
@@ -246,3 +246,11 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <div style="display: flex; gap: 12px;">
+    <button class="btn btn--primary btn--lg">Confirmar</button>
+    <button class="btn btn--secondary btn--lg">Cancelar</button>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/card/Card.docs.mdx
+++ b/packages/lets-ui-components/src/components/card/Card.docs.mdx
@@ -19,3 +19,31 @@ import * as CardStories from './Card.stories';
 ## Full
 
 <Canvas of={CardStories.Full} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={CardStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-card>
+  <p>Conteúdo do card</p>
+  <button slot="actions" class="btn btn--primary btn--lg">Ação</button>
+</lui-card>
+```
+
+### Classe CSS
+
+```html
+<div class="card card--border">
+  <div class="card__body">
+    <p>Conteúdo do card</p>
+  </div>
+  <div class="card__actions">
+    <button class="btn btn--primary btn--lg">Ação</button>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/card/Card.stories.js
+++ b/packages/lets-ui-components/src/components/card/Card.stories.js
@@ -62,3 +62,15 @@ Full.args = {
   primaryButton: 'Confirm',
   secondaryButton: 'Cancel',
 };
+
+export const CSSClass = () => `
+  <div class="card card--border">
+    <div class="card__body">
+      <p>Conteúdo do card</p>
+    </div>
+    <div class="card__actions">
+      <button class="btn btn--primary btn--lg">Ação</button>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/center/Center.docs.mdx
+++ b/packages/lets-ui-components/src/components/center/Center.docs.mdx
@@ -21,3 +21,25 @@ Centering layout with axis control. Useful for hero sections and empty states.
 ## With Max Width
 
 <Canvas of={CenterStories.WithMaxWidth} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={CenterStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-center axis="both" style="height: 300px;">
+  <div>Conteúdo centralizado</div>
+</lui-center>
+```
+
+### Classe CSS
+
+```html
+<div class="center center--horizontal">
+  <div class="center__inner" style="max-width: 400px;">Conteúdo centralizado</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/center/Center.stories.js
+++ b/packages/lets-ui-components/src/components/center/Center.stories.js
@@ -40,3 +40,10 @@ Vertical.args = { axis: 'vertical', minHeight: '', maxWidth: '' };
 
 export const WithMaxWidth = Template.bind({});
 WithMaxWidth.args = { axis: 'both', minHeight: '', maxWidth: '400px' };
+
+export const CSSClass = () => `
+  <div class="center center--horizontal">
+    <div class="center__inner" style="max-width: 400px;">Conteúdo centralizado</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/checkbox/Checkbox.docs.mdx
+++ b/packages/lets-ui-components/src/components/checkbox/Checkbox.docs.mdx
@@ -51,3 +51,24 @@ Com `required`, o form não submete enquanto o checkbox não estiver marcado.
 | `value`    | `string`  | `'on'` | Valor submetido quando marcado; omitido quando desmarcado                       |
 | `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o checkbox fora do elemento form         |
 | `required` | `boolean` | `false`| Bloqueia a submissão quando o checkbox não está marcado                         |
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={CheckboxStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-checkbox size="lg">Aceito os termos</lui-checkbox>
+```
+
+### Classe CSS
+
+```html
+<label class="checkbox checkbox--lg">
+  <input type="checkbox">
+  Aceito os termos
+</label>
+```

--- a/packages/lets-ui-components/src/components/checkbox/Checkbox.stories.js
+++ b/packages/lets-ui-components/src/components/checkbox/Checkbox.stories.js
@@ -150,3 +150,11 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <label class="checkbox checkbox--lg">
+    <input type="checkbox">
+    Aceito os termos
+  </label>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/columns/Columns.docs.mdx
+++ b/packages/lets-ui-components/src/components/columns/Columns.docs.mdx
@@ -27,3 +27,29 @@ Pass a JSON array to define column widths: `columns='["2fr","1fr"]'`.
 ## Collapse on Mobile
 
 <Canvas of={ColumnsStories.CollapseOnMobile} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={ColumnsStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-columns columns="3" gap="md" align="stretch">
+  <lui-column>Coluna 1</lui-column>
+  <lui-column>Coluna 2</lui-column>
+  <lui-column>Coluna 3</lui-column>
+</lui-columns>
+```
+
+### Classe CSS
+
+```html
+<div class="columns columns--3 columns--gap-md">
+  <div class="column">Coluna 1</div>
+  <div class="column">Coluna 2</div>
+  <div class="column">Coluna 3</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/columns/Columns.stories.js
+++ b/packages/lets-ui-components/src/components/columns/Columns.stories.js
@@ -69,3 +69,12 @@ CollapseOnMobile.args = {
   align: 'stretch',
   collapseBelow: 'sm',
 };
+
+export const CSSClass = () => `
+  <div class="columns columns--3 columns--gap-md">
+    <div class="column">Coluna 1</div>
+    <div class="column">Coluna 2</div>
+    <div class="column">Coluna 3</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/container/Container.docs.mdx
+++ b/packages/lets-ui-components/src/components/container/Container.docs.mdx
@@ -17,3 +17,25 @@ Max-width centering wrapper. Controls the readable width of page content.
 ## Full Width
 
 <Canvas of={ContainerStories.Full} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={ContainerStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-container size="md" padding="xl" center>
+  Conteúdo centralizado
+</lui-container>
+```
+
+### Classe CSS
+
+```html
+<div class="container container--md">
+  Conteúdo centralizado
+</div>
+```

--- a/packages/lets-ui-components/src/components/container/Container.stories.js
+++ b/packages/lets-ui-components/src/components/container/Container.stories.js
@@ -39,3 +39,10 @@ Small.args = { size: 'sm', padding: 'md', center: true, as: 'div' };
 
 export const Full = Template.bind({});
 Full.args = { size: 'full', padding: 'lg', center: false, as: 'div' };
+
+export const CSSClass = () => `
+  <div class="container container--md">
+    Conteúdo centralizado
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/divider/Divider.docs.mdx
+++ b/packages/lets-ui-components/src/components/divider/Divider.docs.mdx
@@ -25,3 +25,34 @@ Use `orientation="vertical"` (web component) ou a classe `.divider--vertical` (H
 ## Vertical com label
 
 <Canvas of={DividerStories.VerticalWithLabel} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={DividerStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<!-- Horizontal -->
+<lui-divider></lui-divider>
+
+<!-- Horizontal com label -->
+<lui-divider label="ou"></lui-divider>
+
+<!-- Vertical -->
+<lui-divider orientation="vertical"></lui-divider>
+```
+
+### Classe CSS
+
+```html
+<hr class="divider">
+<!-- Vertical: -->
+<div class="divider divider--vertical"></div>
+<!-- Com label: -->
+<div class="divider divider--labeled">
+  <span class="divider__label">ou</span>
+</div>
+```

--- a/packages/lets-ui-components/src/components/divider/Divider.stories.js
+++ b/packages/lets-ui-components/src/components/divider/Divider.stories.js
@@ -58,3 +58,16 @@ export const VerticalWithLabel = () => `
     <span>Abaixo</span>
   </div>
 `;
+
+export const CSSClass = () => `
+  <div style="padding: 16px; background: white; border-radius: 8px; width: 320px;">
+    <p style="margin: 0 0 16px;">Seção acima</p>
+    <hr class="divider">
+    <p style="margin: 16px 0 8px;">Com label:</p>
+    <div class="divider divider--labeled">
+      <span class="divider__label">ou</span>
+    </div>
+    <p style="margin: 8px 0 0;">Seção abaixo</p>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/drawer/Drawer.docs.mdx
+++ b/packages/lets-ui-components/src/components/drawer/Drawer.docs.mdx
@@ -28,3 +28,36 @@ Omita `primary-button` e `secondary-button` quando o drawer for apenas informati
 Por padrão o backdrop não fecha o drawer. Ative `close-on-backdrop` quando o fluxo permitir descarte acidental. Desative em formulários ou fluxos onde o usuário deve tomar uma decisão explícita.
 
 <Canvas of={DrawerStories.CloseOnBackdropOff} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={DrawerStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-drawer title="Título" size="md" trigger-label="Abrir drawer" close-on-backdrop>
+  <p>Conteúdo do drawer</p>
+  <button slot="actions" data-drawer-close class="btn btn--secondary btn--lg">Cancelar</button>
+  <button slot="actions" class="btn btn--primary btn--lg">Confirmar</button>
+</lui-drawer>
+```
+
+### Classe CSS
+
+```html
+<div class="drawer-backdrop is-open"></div>
+<div class="drawer drawer--md is-open" role="dialog" aria-modal="true">
+  <div class="drawer__header">
+    <span class="drawer__title">Título</span>
+    <button class="drawer__close" aria-label="Fechar">×</button>
+  </div>
+  <div class="drawer__body">Conteúdo do drawer</div>
+  <div class="drawer__footer">
+    <button class="btn btn--secondary btn--lg">Cancelar</button>
+    <button class="btn btn--primary btn--lg">Confirmar</button>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/drawer/Drawer.stories.js
+++ b/packages/lets-ui-components/src/components/drawer/Drawer.stories.js
@@ -96,3 +96,20 @@ export const CustomTrigger = () => `
   </lui-drawer>
 `;
 CustomTrigger.storyName = 'Trigger customizado (slot)';
+
+export const CSSClass = () => `
+  <div class="drawer-backdrop is-open" style="position: relative; width: 100%; height: 400px; background: rgba(0,0,0,0.3);">
+    <div class="drawer drawer--md is-open" role="dialog" aria-modal="true" style="position: absolute; right: 0; top: 0; height: 100%;">
+      <div class="drawer__header">
+        <span class="drawer__title">Título</span>
+        <button class="drawer__close" aria-label="Fechar">×</button>
+      </div>
+      <div class="drawer__body">Conteúdo do drawer</div>
+      <div class="drawer__footer">
+        <button class="btn btn--secondary btn--lg">Cancelar</button>
+        <button class="btn btn--primary btn--lg">Confirmar</button>
+      </div>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/dropdown-menu/DropdownMenu.docs.mdx
+++ b/packages/lets-ui-components/src/components/dropdown-menu/DropdownMenu.docs.mdx
@@ -33,3 +33,32 @@ Use divisores para separar visualmente grupos de ações com propósitos distint
 Use para indicar ações temporariamente indisponíveis sem remover a opção da interface.
 
 <Canvas of={DropdownMenuStories.WithDisabledItem} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={DropdownMenuStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-dropdown-menu>
+  <lui-button slot="trigger" variant="secondary" size="md" label="Opções"></lui-button>
+  <lui-menu-item slot="items" label="Editar" shortcut="⌘,E"></lui-menu-item>
+  <lui-menu-divider slot="items"></lui-menu-divider>
+  <lui-menu-item slot="items" label="Excluir" variant="danger"></lui-menu-item>
+</lui-dropdown-menu>
+```
+
+### Classe CSS
+
+```html
+<div class="dropdown-menu">
+  <button class="btn btn--secondary btn--md" aria-expanded="false">Opções</button>
+  <div class="dropdown-menu__panel is-open">
+    <button class="menu-item"><span class="menu-item__label">Editar</span></button>
+    <button class="menu-item menu-item--danger"><span class="menu-item__label">Excluir</span></button>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/dropdown-menu/DropdownMenu.stories.js
+++ b/packages/lets-ui-components/src/components/dropdown-menu/DropdownMenu.stories.js
@@ -91,3 +91,14 @@ export const WithDisabledItem = () => `
     </lui-dropdown-menu>
   </div>
 `;
+
+export const CSSClass = () => `
+  <div class="dropdown-menu" style="margin-bottom: 120px;">
+    <button class="btn btn--secondary btn--md" aria-expanded="false">Opções</button>
+    <div class="dropdown-menu__panel is-open">
+      <button class="menu-item"><span class="menu-item__label">Editar</span></button>
+      <button class="menu-item menu-item--danger"><span class="menu-item__label">Excluir</span></button>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/flex/Flex.docs.mdx
+++ b/packages/lets-ui-components/src/components/flex/Flex.docs.mdx
@@ -17,3 +17,27 @@ Raw flexbox primitive. Use `lui-flex-item` to control individual item properties
 ## With Flex Grow
 
 <Canvas of={FlexStories.WithGrow} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={FlexStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-flex gap="md" align="stretch" justify="start">
+  <lui-flex-item grow="1">Cresce</lui-flex-item>
+  <lui-flex-item>Fixo</lui-flex-item>
+</lui-flex>
+```
+
+### Classe CSS
+
+```html
+<div class="flex flex--gap-md flex--align-center">
+  <div class="flex-item--grow">Cresce</div>
+  <div class="flex-item--shrink-0">Fixo</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/flex/Flex.stories.js
+++ b/packages/lets-ui-components/src/components/flex/Flex.stories.js
@@ -84,3 +84,11 @@ export const WithGrow = () => `
     </lui-flex>
   </div>
 `;
+
+export const CSSClass = () => `
+  <div class="flex flex--gap-md flex--align-center">
+    <div class="flex-item--grow">Cresce</div>
+    <div class="flex-item--shrink-0">Fixo</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/grid/Grid.docs.mdx
+++ b/packages/lets-ui-components/src/components/grid/Grid.docs.mdx
@@ -17,3 +17,29 @@ Full CSS Grid layout primitive. Use `lui-grid-item` for individual items with sp
 ## With Column Spans
 
 <Canvas of={GridStories.WithSpans} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={GridStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-grid columns="repeat(3, 1fr)" gap="md">
+  <lui-grid-item>Item 1</lui-grid-item>
+  <lui-grid-item>Item 2</lui-grid-item>
+  <lui-grid-item>Item 3</lui-grid-item>
+</lui-grid>
+```
+
+### Classe CSS
+
+```html
+<div class="grid grid--gap-md" style="grid-template-columns: repeat(3, 1fr);">
+  <div class="grid-item">Item 1</div>
+  <div class="grid-item">Item 2</div>
+  <div class="grid-item">Item 3</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/grid/Grid.stories.js
+++ b/packages/lets-ui-components/src/components/grid/Grid.stories.js
@@ -62,3 +62,12 @@ export const WithSpans = () => `
     ${cell('1 col', '#ede9fe')}
   </lui-grid>
 `;
+
+export const CSSClass = () => `
+  <div class="grid grid--gap-md" style="grid-template-columns: repeat(3, 1fr);">
+    <div class="grid-item">Item 1</div>
+    <div class="grid-item">Item 2</div>
+    <div class="grid-item">Item 3</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/heading/Heading.docs.mdx
+++ b/packages/lets-ui-components/src/components/heading/Heading.docs.mdx
@@ -41,3 +41,21 @@ Use `align` com `left`, `center`, `right` ou `justify`.
 O atributo `line-clamp` recebe um número inteiro e limita a exibição do texto.
 
 <Canvas of={HeadingStories.WithLineClamp} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={HeadingStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-heading variant="title" color="heading" label="Título da página"></lui-heading>
+```
+
+### Classe CSS
+
+```html
+<h1 class="title text--color-heading">Título da página</h1>
+```

--- a/packages/lets-ui-components/src/components/heading/Heading.stories.js
+++ b/packages/lets-ui-components/src/components/heading/Heading.stories.js
@@ -3,7 +3,7 @@ import '../../../../../packages/styles/dist/letsui.css';
 import '../../index.js';
 
 export default {
-  title: 'Content/Typography/Heading',
+  title: 'Typography/Heading',
   argTypes: {
     variant: {
       control: { type: 'select' },
@@ -120,3 +120,8 @@ export const WithLineClamp = () => `
     style="max-width: 400px; display: block;"
   ></lui-heading>
 `;
+
+export const CSSClass = () => `
+  <h1 class="title text--color-heading">Título da página</h1>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/icon-button/IconButton.docs.mdx
+++ b/packages/lets-ui-components/src/components/icon-button/IconButton.docs.mdx
@@ -28,3 +28,25 @@ Use o estado desabilitado quando a ação não está disponível no contexto atu
 Exemplos de uso com ícones SVG. O slot aceita qualquer SVG ou ícone de qualquer biblioteca.
 
 <Canvas of={IconButtonStories.AllIcons} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={IconButtonStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-icon-button size="lg" aria-label="Fechar">
+  <svg width="24" height="24" ...>...</svg>
+</lui-icon-button>
+```
+
+### Classe CSS
+
+```html
+<button class="icon-button icon-button--lg" aria-label="Fechar">
+  <svg width="24" height="24" ...>...</svg>
+</button>
+```

--- a/packages/lets-ui-components/src/components/icon-button/IconButton.stories.js
+++ b/packages/lets-ui-components/src/components/icon-button/IconButton.stories.js
@@ -82,3 +82,12 @@ export const AllIcons = () => `
   </div>
 `;
 AllIcons.parameters = { controls: { disable: true } };
+
+export const CSSClass = () => `
+  <button class="icon-button icon-button--lg" aria-label="Fechar">
+    <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M17.4697 5.46973C17.7626 5.17683 18.2373 5.17683 18.5302 5.46973C18.8231 5.76262 18.8231 6.23738 18.5302 6.53027L13.0605 12L18.5302 17.4697C18.8231 17.7626 18.8231 18.2374 18.5302 18.5303C18.2373 18.8232 17.7626 18.8232 17.4697 18.5303L11.9999 13.0605L6.53022 18.5303C6.23732 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9394 12L5.46967 6.53027C5.17678 6.23738 5.17678 5.76262 5.46967 5.46973C5.76256 5.17683 6.23732 5.17683 6.53022 5.46973L11.9999 10.9395L17.4697 5.46973Z"/>
+    </svg>
+  </button>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/image/Image.docs.mdx
+++ b/packages/lets-ui-components/src/components/image/Image.docs.mdx
@@ -51,3 +51,30 @@ Provide an alternative image to display when the primary `src` fails to load.
 Use `as="picture"` to render a `<picture>` wrapper (for art-direction with `<source>` elements).
 
 <Canvas of={ImageStories.AsPicture} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={ImageStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-image
+  src="..."
+  alt="Descrição"
+  width="400px"
+  aspect-ratio="16 / 9"
+  radius="md"
+  fit="cover"
+></lui-image>
+```
+
+### Classe CSS
+
+```html
+<div class="img" style="width: 400px; aspect-ratio: 16 / 9; border-radius: 8px;">
+  <img class="img__element" src="..." alt="Descrição">
+</div>
+```

--- a/packages/lets-ui-components/src/components/image/Image.stories.js
+++ b/packages/lets-ui-components/src/components/image/Image.stories.js
@@ -206,3 +206,10 @@ export const AsPicture = () => `
     loading="eager"
   ></lui-image>
 `;
+
+export const CSSClass = () => `
+  <div class="img" style="width: 400px; aspect-ratio: 16 / 9; border-radius: 8px;">
+    <img class="img__element" src="${SAMPLE_SRC}" alt="Mountain landscape">
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/inline/Inline.docs.mdx
+++ b/packages/lets-ui-components/src/components/inline/Inline.docs.mdx
@@ -17,3 +17,29 @@ Horizontal flex layout with wrapping support. Great for tags, chips, and button 
 ## No Wrap
 
 <Canvas of={InlineStories.NoWrap} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={InlineStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-inline gap="sm" align="center" justify="start" wrap="wrap">
+  <span>Design</span>
+  <span>Engineering</span>
+  <span>Product</span>
+</lui-inline>
+```
+
+### Classe CSS
+
+```html
+<div class="inline inline--gap-sm">
+  <span>Design</span>
+  <span>Engineering</span>
+  <span>Product</span>
+</div>
+```

--- a/packages/lets-ui-components/src/components/inline/Inline.stories.js
+++ b/packages/lets-ui-components/src/components/inline/Inline.stories.js
@@ -59,3 +59,12 @@ SpaceBetween.args = {
 
 export const NoWrap = Template.bind({});
 NoWrap.args = { gap: 'sm', align: 'center', justify: 'start', wrap: 'nowrap' };
+
+export const CSSClass = () => `
+  <div class="inline inline--gap-sm">
+    <span>Design</span>
+    <span>Engineering</span>
+    <span>Product</span>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/input/Input.docs.mdx
+++ b/packages/lets-ui-components/src/components/input/Input.docs.mdx
@@ -50,3 +50,35 @@ consistente com elementos nativos. A mensagem reportada é controlada pelo atrib
 | `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`   |
 | `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o input fora do elemento form         |
 | `required` | `boolean` | `false`| Bloqueia a submissão quando o campo está vazio; valida via `ElementInternals`|
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={InputStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-input
+  type="email"
+  label="Email"
+  placeholder="seu@email.com"
+  size="lg"
+></lui-input>
+```
+
+### Classe CSS
+
+```html
+<div class="input-field input-field--lg">
+  <div class="input-field__head">
+    <div class="input-field__label-wrap">
+      <label class="input-field__label">Email</label>
+    </div>
+  </div>
+  <div class="input-field__control">
+    <input type="email" class="input-field__input" placeholder="seu@email.com">
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/input/Input.stories.js
+++ b/packages/lets-ui-components/src/components/input/Input.stories.js
@@ -279,3 +279,17 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <div class="input-field input-field--lg">
+    <div class="input-field__head">
+      <div class="input-field__label-wrap">
+        <label class="input-field__label">Email</label>
+      </div>
+    </div>
+    <div class="input-field__control">
+      <input type="email" class="input-field__input" placeholder="seu@email.com">
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/modal/Modal.docs.mdx
+++ b/packages/lets-ui-components/src/components/modal/Modal.docs.mdx
@@ -31,3 +31,35 @@ Omit the `actions` slot to render a modal with no footer.
 Slot any element with `slot="trigger"` to replace the default trigger button.
 
 <Canvas of={ModalStories.CustomTrigger} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={ModalStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-modal title="Título" size="md" trigger-label="Abrir modal">
+  <p>Conteúdo do modal</p>
+  <lui-button slot="actions" variant="secondary" label="Cancelar" data-modal-close></lui-button>
+  <lui-button slot="actions" label="Confirmar"></lui-button>
+</lui-modal>
+```
+
+### Classe CSS
+
+```html
+<div class="modal modal--md" role="dialog" aria-modal="true">
+  <div class="modal__header">
+    <span class="modal__title">Título</span>
+    <button class="modal__close" aria-label="Fechar">×</button>
+  </div>
+  <div class="modal__body">Conteúdo do modal</div>
+  <div class="modal__footer">
+    <button class="btn btn--secondary btn--lg">Cancelar</button>
+    <button class="btn btn--primary btn--lg">Confirmar</button>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/modal/Modal.stories.js
+++ b/packages/lets-ui-components/src/components/modal/Modal.stories.js
@@ -72,3 +72,18 @@ export const CustomTrigger = () => `
   </lui-modal>
 `;
 CustomTrigger.storyName = 'Custom trigger (slot)';
+
+export const CSSClass = () => `
+  <div class="modal modal--md" role="dialog" aria-modal="true">
+    <div class="modal__header">
+      <span class="modal__title">Título</span>
+      <button class="modal__close" aria-label="Fechar">×</button>
+    </div>
+    <div class="modal__body">Conteúdo do modal</div>
+    <div class="modal__footer">
+      <button class="btn btn--secondary btn--lg">Cancelar</button>
+      <button class="btn btn--primary btn--lg">Confirmar</button>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/radio-group/RadioGroup.docs.mdx
+++ b/packages/lets-ui-components/src/components/radio-group/RadioGroup.docs.mdx
@@ -61,3 +61,34 @@ O valor selecionado é submetido no `FormData` com a chave `name` do grupo. Múl
 | `error`      | `boolean` | `false`                 | Ativa o estado de erro manualmente                                |
 | `error-text` | `string`  | `'Selecione uma opção.'`| Mensagem exibida abaixo do grupo quando `error` é verdadeiro      |
 | `form`       | `string`  | `''`                    | ID do `<form>` associado; permite usar o grupo fora do `<form>`   |
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={RadioGroupStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-radio-group name="plano" label="Plano" size="lg">
+  <lui-radio value="basic" label="Básico"></lui-radio>
+  <lui-radio value="pro" label="Pro"></lui-radio>
+</lui-radio-group>
+```
+
+### Classe CSS
+
+```html
+<fieldset class="radio-group radio-group--lg">
+  <legend class="radio-group__legend">Plano</legend>
+  <div class="radio-group__options">
+    <label class="radio">
+      <input type="radio" name="plano" value="basic"> Básico
+    </label>
+    <label class="radio">
+      <input type="radio" name="plano" value="pro"> Pro
+    </label>
+  </div>
+</fieldset>
+```

--- a/packages/lets-ui-components/src/components/radio-group/RadioGroup.stories.js
+++ b/packages/lets-ui-components/src/components/radio-group/RadioGroup.stories.js
@@ -229,3 +229,18 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <fieldset class="radio-group radio-group--lg">
+    <legend class="radio-group__legend">Plano</legend>
+    <div class="radio-group__options">
+      <label class="radio">
+        <input type="radio" name="plano" value="basic"> Básico
+      </label>
+      <label class="radio">
+        <input type="radio" name="plano" value="pro"> Pro
+      </label>
+    </div>
+  </fieldset>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/radio/Radio.docs.mdx
+++ b/packages/lets-ui-components/src/components/radio/Radio.docs.mdx
@@ -37,3 +37,24 @@ O atributo `label` renderiza o texto como conteúdo padrão do slot. Útil para 
 | `checked`    | `boolean`       | `false`| Estado marcado                                              |
 | `disabled`   | `boolean`       | `false`| Desabilita o radio                                          |
 | `size`       | `'lg' \| 'md'` | `'lg'` | Controlado pelo `lui-radio-group`; raramente definido direto|
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={RadioStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-radio value="a" size="lg">Opção A</lui-radio>
+```
+
+### Classe CSS
+
+```html
+<label class="radio radio--lg">
+  <input type="radio" name="opcao" value="a">
+  Opção A
+</label>
+```

--- a/packages/lets-ui-components/src/components/radio/Radio.stories.js
+++ b/packages/lets-ui-components/src/components/radio/Radio.stories.js
@@ -66,3 +66,11 @@ export const Small = () =>
 
 export const Disabled = () =>
   `<lui-radio value="option" checked disabled size="lg">Desabilitado</lui-radio>`;
+
+export const CSSClass = () => `
+  <label class="radio radio--lg">
+    <input type="radio" name="opcao" value="a">
+    Opção A
+  </label>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/select/Select.docs.mdx
+++ b/packages/lets-ui-components/src/components/select/Select.docs.mdx
@@ -39,3 +39,39 @@ Com `required`, o form não submete enquanto o placeholder estiver ativo (nenhum
 | `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`       |
 | `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o select fora do elemento form            |
 | `required` | `boolean` | `false`| Bloqueia a submissão enquanto o placeholder estiver selecionado                  |
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={SelectStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-native-select
+  label="País"
+  placeholder="Selecione..."
+  options="Brasil,Portugal"
+  size="lg"
+></lui-native-select>
+```
+
+### Classe CSS
+
+```html
+<div class="native-select native-select--lg">
+  <div class="native-select__head">
+    <label class="native-select__label">País</label>
+  </div>
+  <div class="native-select__control">
+    <select class="native-select__input">
+      <option value="">Selecione...</option>
+      <option value="br">Brasil</option>
+    </select>
+    <span class="native-select__arrow">
+      <svg ...>...</svg>
+    </span>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/select/Select.stories.js
+++ b/packages/lets-ui-components/src/components/select/Select.stories.js
@@ -204,3 +204,23 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <div class="native-select native-select--lg">
+    <div class="native-select__head">
+      <label class="native-select__label">País</label>
+    </div>
+    <div class="native-select__control">
+      <select class="native-select__input">
+        <option value="">Selecione...</option>
+        <option value="br">Brasil</option>
+      </select>
+      <span class="native-select__arrow">
+        <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M18.2197 8.46973C18.5126 8.17683 18.9874 8.17683 19.2803 8.46973C19.5732 8.76262 19.5732 9.23738 19.2803 9.53027L12.5303 16.2803C12.2374 16.5732 11.7626 16.5732 11.4697 16.2803L4.71973 9.53027C4.42684 9.23738 4.42684 8.76262 4.71973 8.46973C5.01262 8.17683 5.48738 8.17683 5.78028 8.46973L12 14.6895L18.2197 8.46973Z"/>
+        </svg>
+      </span>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/shortcut/Shortcut.docs.mdx
+++ b/packages/lets-ui-components/src/components/shortcut/Shortcut.docs.mdx
@@ -27,3 +27,25 @@ Use quando o atalho exige uma combinação de teclas simultâneas. Passe as tecl
 Combine com listas de ações ou menus para documentar atalhos disponíveis na interface. O componente se alinha naturalmente em layouts `flex` com `justify-content: space-between`.
 
 <Canvas of={ShortcutStories.InContext} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={ShortcutStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-shortcut keys="⌘,K"></lui-shortcut>
+```
+
+### Classe CSS
+
+```html
+<span class="shortcut">
+  <kbd class="shortcut__key">⌘</kbd>
+  <span class="shortcut__sep">+</span>
+  <kbd class="shortcut__key">K</kbd>
+</span>
+```

--- a/packages/lets-ui-components/src/components/shortcut/Shortcut.stories.js
+++ b/packages/lets-ui-components/src/components/shortcut/Shortcut.stories.js
@@ -3,7 +3,7 @@ import '../../../../../packages/styles/dist/letsui.css';
 import '../../index.js';
 
 export default {
-  title: 'Miscellaneous/Shortcut',
+  title: 'Typography/Shortcut',
   argTypes: {
     keys: {
       control: 'text',
@@ -58,3 +58,12 @@ export const InContext = () => `
     </ul>
   </div>
 `;
+
+export const CSSClass = () => `
+  <span class="shortcut">
+    <kbd class="shortcut__key">⌘</kbd>
+    <span class="shortcut__sep">+</span>
+    <kbd class="shortcut__key">K</kbd>
+  </span>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/sidebar/Sidebar.docs.mdx
+++ b/packages/lets-ui-components/src/components/sidebar/Sidebar.docs.mdx
@@ -17,3 +17,27 @@ Two-panel layout with a fixed-width sidebar and flexible content area. Uses name
 ## Narrow Sidebar
 
 <Canvas of={SidebarStories.NarrowSidebar} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={SidebarStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-sidebar side="start" side-width="240px" content-min-width="50%" gap="lg" align="stretch">
+  <div slot="sidebar">Navegação ou metadados</div>
+  <div slot="content">Conteúdo principal</div>
+</lui-sidebar>
+```
+
+### Classe CSS
+
+```html
+<div class="sidebar sidebar--gap-md">
+  <div class="sidebar__side">Sidebar (240px)</div>
+  <div class="sidebar__content">Conteúdo principal</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/sidebar/Sidebar.stories.js
+++ b/packages/lets-ui-components/src/components/sidebar/Sidebar.stories.js
@@ -65,3 +65,11 @@ NarrowSidebar.args = {
   gap: 'md',
   align: 'stretch',
 };
+
+export const CSSClass = () => `
+  <div class="sidebar sidebar--gap-md">
+    <div class="sidebar__side">Sidebar (240px)</div>
+    <div class="sidebar__content">Conteúdo principal</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/stack/Stack.docs.mdx
+++ b/packages/lets-ui-components/src/components/stack/Stack.docs.mdx
@@ -17,3 +17,29 @@ Vertical flex layout that stacks children with consistent spacing.
 ## Centered Items
 
 <Canvas of={StackStories.Centered} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={StackStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-stack gap="md" align="stretch" justify="start">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</lui-stack>
+```
+
+### Classe CSS
+
+```html
+<div class="stack stack--gap-md">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/stack/Stack.stories.js
+++ b/packages/lets-ui-components/src/components/stack/Stack.stories.js
@@ -55,3 +55,12 @@ SpaceBetween.args = { gap: 'md', align: 'stretch', justify: 'space-between' };
 SpaceBetween.decorators = [
   (story) => `<div style="height: 240px;">${story()}</div>`,
 ];
+
+export const CSSClass = () => `
+  <div class="stack stack--gap-md">
+    <div>Item 1</div>
+    <div>Item 2</div>
+    <div>Item 3</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/switch/Switch.docs.mdx
+++ b/packages/lets-ui-components/src/components/switch/Switch.docs.mdx
@@ -53,3 +53,24 @@ O `lui-switch` é form-associated. Use `name` para identificar o campo no `FormD
 | `value`    | `string`  | `'on'` | Valor submetido quando ativado; omitido quando desativado                       |
 | `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o switch fora do elemento form           |
 | `required` | `boolean` | `false`| Bloqueia a submissão quando o switch não está ativado                           |
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={SwitchStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-switch size="lg">Notificações</lui-switch>
+```
+
+### Classe CSS
+
+```html
+<label class="switch switch--lg">
+  <input type="checkbox">
+  Notificações
+</label>
+```

--- a/packages/lets-ui-components/src/components/switch/Switch.stories.js
+++ b/packages/lets-ui-components/src/components/switch/Switch.stories.js
@@ -144,3 +144,11 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <label class="switch switch--lg">
+    <input type="checkbox">
+    Notificações
+  </label>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/switcher/Switcher.docs.mdx
+++ b/packages/lets-ui-components/src/components/switcher/Switcher.docs.mdx
@@ -13,3 +13,29 @@ Intrinsic responsive layout using the Every Layout switcher pattern. Children sw
 ## Wide Threshold
 
 <Canvas of={SwitcherStories.WideThreshold} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={SwitcherStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-switcher threshold="320px" gap="md">
+  <div>Panel A</div>
+  <div>Panel B</div>
+  <div>Panel C</div>
+</lui-switcher>
+```
+
+### Classe CSS
+
+```html
+<div class="switcher switcher--gap-md">
+  <div>Panel A</div>
+  <div>Panel B</div>
+  <div>Panel C</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/switcher/Switcher.stories.js
+++ b/packages/lets-ui-components/src/components/switcher/Switcher.stories.js
@@ -32,3 +32,12 @@ Default.args = { threshold: '320px', gap: 'md' };
 
 export const WideThreshold = Template.bind({});
 WideThreshold.args = { threshold: '500px', gap: 'lg' };
+
+export const CSSClass = () => `
+  <div class="switcher switcher--gap-md">
+    <div>Panel A</div>
+    <div>Panel B</div>
+    <div>Panel C</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/tabs/Tabs.docs.mdx
+++ b/packages/lets-ui-components/src/components/tabs/Tabs.docs.mdx
@@ -31,3 +31,31 @@ Componente de navegação por abas. Suporta dois estilos visuais — **Line** (i
 ## Com aba desabilitada
 
 <Canvas of={TabsStories.WithDisabledTab} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={TabsStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-tabs variant="line">
+  <lui-tab label="Geral" active><p>Conteúdo da aba Geral.</p></lui-tab>
+  <lui-tab label="Segurança"><p>Conteúdo da aba Segurança.</p></lui-tab>
+</lui-tabs>
+```
+
+### Classe CSS
+
+```html
+<div class="tabs tabs--line">
+  <div class="tabs__list">
+    <button class="tab" role="tab" aria-selected="true">Geral</button>
+    <button class="tab" role="tab" aria-selected="false">Segurança</button>
+  </div>
+  <div class="tabs__panel" role="tabpanel">Conteúdo da tab Geral</div>
+  <div class="tabs__panel" role="tabpanel" hidden>Conteúdo da tab Segurança</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/tabs/Tabs.stories.js
+++ b/packages/lets-ui-components/src/components/tabs/Tabs.stories.js
@@ -74,3 +74,15 @@ export const WithDisabledTab = () => `
 `;
 WithDisabledTab.storyName = 'Com aba desabilitada';
 WithDisabledTab.parameters = { controls: { disable: true } };
+
+export const CSSClass = () => `
+  <div class="tabs tabs--line">
+    <div class="tabs__list">
+      <button class="tab" role="tab" aria-selected="true">Geral</button>
+      <button class="tab" role="tab" aria-selected="false">Segurança</button>
+    </div>
+    <div class="tabs__panel" role="tabpanel">Conteúdo da tab Geral</div>
+    <div class="tabs__panel" role="tabpanel" hidden>Conteúdo da tab Segurança</div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/tag/Tag.stories.js
+++ b/packages/lets-ui-components/src/components/tag/Tag.stories.js
@@ -85,3 +85,8 @@ SizeMd.args = {
   variant: 'primary',
   size: 'md',
 };
+
+export const CSSClass = () => `
+  <span class="tag-md tag--md tag--surface-primary">Label</span>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/textarea/Textarea.docs.mdx
+++ b/packages/lets-ui-components/src/components/textarea/Textarea.docs.mdx
@@ -55,3 +55,33 @@ Com `required`, o campo bloqueia a submissão quando está vazio via `ElementInt
 | `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`    |
 | `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o textarea fora do elemento form       |
 | `required` | `boolean` | `false`| Bloqueia a submissão quando o campo está vazio; valida via `ElementInternals` |
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={TextareaStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-textarea
+  label="Mensagem"
+  placeholder="Digite..."
+  size="lg"
+  rows="4"
+></lui-textarea>
+```
+
+### Classe CSS
+
+```html
+<div class="textarea-field textarea-field--lg">
+  <div class="textarea-field__head">
+    <label class="textarea-field__label">Mensagem</label>
+  </div>
+  <div class="textarea-field__control">
+    <textarea class="textarea-field__input" rows="4" placeholder="Digite..."></textarea>
+  </div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/textarea/Textarea.stories.js
+++ b/packages/lets-ui-components/src/components/textarea/Textarea.stories.js
@@ -226,3 +226,15 @@ FormIntegration.parameters = {
     },
   },
 };
+
+export const CSSClass = () => `
+  <div class="textarea-field textarea-field--lg">
+    <div class="textarea-field__head">
+      <label class="textarea-field__label">Mensagem</label>
+    </div>
+    <div class="textarea-field__control">
+      <textarea class="textarea-field__input" rows="4" placeholder="Digite..."></textarea>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/tooltip/Tooltip.docs.mdx
+++ b/packages/lets-ui-components/src/components/tooltip/Tooltip.docs.mdx
@@ -21,3 +21,24 @@ Use the `position` attribute to control where the tooltip appears relative to it
 Slot any focusable element inside `<lui-tooltip>` to use it as the trigger. The component automatically wires up `aria-describedby` on focusable children.
 
 <Canvas of={TooltipStories.WithCustomTrigger} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={TooltipStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-tooltip text="Texto do tooltip" position="top" label="Hover aqui"></lui-tooltip>
+```
+
+### Classe CSS
+
+```html
+<div class="tooltip tooltip--top">
+  <button class="tooltip__trigger">Hover aqui</button>
+  <div role="tooltip" class="tooltip__content">Texto do tooltip</div>
+</div>
+```

--- a/packages/lets-ui-components/src/components/tooltip/Tooltip.stories.js
+++ b/packages/lets-ui-components/src/components/tooltip/Tooltip.stories.js
@@ -62,3 +62,13 @@ export const WithCustomTrigger = () => `
     </lui-tooltip>
   </div>
 `;
+
+export const CSSClass = () => `
+  <div style="padding: 80px; display: flex; justify-content: center;">
+    <div class="tooltip tooltip--top">
+      <button class="tooltip__trigger">Hover aqui</button>
+      <div role="tooltip" class="tooltip__content">Texto do tooltip</div>
+    </div>
+  </div>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';


### PR DESCRIPTION
## Summary

- Adds a `CSSClass` story to every component's `.stories.js`, showing a live demo using plain HTML + CSS classes (no `<lui-*>` web components)
- Adds `## Classe CSS (sem Web Component)` section with a live Canvas to every `.docs.mdx`
- Adds `## Uso` section with two code blocks — `### Web Component` and `### Classe CSS` — to every `.docs.mdx`, following the pattern already in `lui-link`
- Removes all `.vanilla.stories.js` files in favor of this integrated approach
- Covers 32 components with MDX + 1 (tag) stories-only

## Test plan

- [ ] Run `pnpm storybook` and verify each component shows the "Classe CSS (sem Web Component)" story at the end of its list
- [ ] Verify the MDX docs page for each component shows the `## Uso` section with both code blocks
- [ ] Confirm no `.vanilla.stories.js` files remain in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)