### PR TITLE
feat(input): add mask support for CPF, CNPJ, CEP, date and credit card

### DIFF
--- a/.changeset/late-adults-lead.md
+++ b/.changeset/late-adults-lead.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/tokens': minor
+'@lets-ui/styles': minor
+---
+
+Add `mask` attribute to `lui-input` for formatted input — built-in support for CEP, CPF, CNPJ (new alphanumeric model), date, credit card number, and card expiry, with no external dependency.

--- a/packages/lets-ui-components/src/components/input/Input.docs.mdx
+++ b/packages/lets-ui-components/src/components/input/Input.docs.mdx
@@ -16,6 +16,47 @@ import * as InputStories from './Input.stories';
 
 <Canvas of={InputStories.NumberInput} />
 
+## Mask
+
+O atributo `mask` formata o valor automaticamente enquanto o usuário digita, sem nenhuma
+dependência externa. A sintaxe usa dois tipos de placeholder:
+
+| Placeholder | Aceita           |
+| ----------- | ---------------- |
+| `9`         | Apenas dígito     |
+| `*`         | Letra ou dígito (convertida para maiúscula) |
+
+Qualquer outro caractere no padrão (`.`, `-`, `/`, espaço) é tratado como literal e inserido
+automaticamente conforme o usuário avança no preenchimento.
+
+<Canvas of={InputStories.Mask} />
+
+### Padrões prontos
+
+| Campo                | Padrão                  |
+| --------------------- | ----------------------- |
+| CEP                   | `99999-999`             |
+| CPF                   | `999.999.999-99`        |
+| CNPJ (modelo alfanumérico, vigente a partir de 2026) | `**.***.***/****-99` — os 12 primeiros caracteres aceitam letra ou dígito; os 2 dígitos verificadores finais são sempre numéricos |
+| Data                  | `99/99/9999`             |
+| Número do cartão      | `9999 9999 9999 9999` (agrupamento genérico 4-4-4-4; bandeiras com outro tamanho, como Amex, não são cobertas) |
+| Validade do cartão    | `99/99`                   |
+
+<Canvas of={InputStories.MaskExamples} />
+
+### Valor emitido
+
+O `mask` afeta apenas a exibição/digitação: o `value`, o `FormData` do form e os eventos
+`input`/`change` sempre carregam a string já formatada (com pontuação), do mesmo jeito que um
+`<input>` nativo exporia `.value`. Se a aplicação precisar apenas dos dígitos (ou de letras e
+dígitos, no caso do CNPJ), remova a pontuação no consumidor, por exemplo
+`value.replace(/[^0-9a-zA-Z]/g, '')`.
+
+Digitar um caractere que não corresponde ao tipo esperado naquela posição (por exemplo, uma
+letra em um campo `9999-999`) é ignorado silenciosamente. Apagar com backspace sobre um
+caractere literal (como o `-` do CEP) também remove o dígito/letra anterior, para que o
+backspace nunca pareça "travado" na pontuação.
+
 ## Error
 
 <Canvas of={InputStories.Error} />

--- a/packages/lets-ui-components/src/components/input/Input.stories.js
+++ b/packages/lets-ui-components/src/components/input/Input.stories.js
@@ -73,6 +73,9 @@ export default {
     step: {
       control: 'number',
     },
+    mask: {
+      control: 'text',
+    },
   },
 };
 
@@ -97,6 +100,7 @@ const Template = ({
   min,
   max,
   step,
+  mask,
 }) => {
   const attrs = [
     `type="${type ?? 'text'}"`,
@@ -121,6 +125,7 @@ const Template = ({
     Number.isFinite(Number(min)) ? `min="${Number(min)}"` : '',
     Number.isFinite(Number(max)) ? `max="${Number(max)}"` : '',
     Number.isFinite(Number(step)) ? `step="${Number(step)}"` : '',
+    mask ? `mask="${mask}"` : '',
   ]
     .filter(Boolean)
     .join('\n  ');
@@ -150,6 +155,7 @@ Input.args = {
   min: undefined,
   max: undefined,
   step: undefined,
+  mask: '',
 };
 
 export const Error = () => `
@@ -201,6 +207,49 @@ export const NumberInput = () => `
     ></lui-input>
   </div>
 `;
+
+export const Mask = () => `
+  <div style="width: 244px;">
+    <lui-input
+      label="CPF"
+      mask="999.999.999-99"
+      placeholder="000.000.000-00"
+      size="lg"
+    ></lui-input>
+  </div>
+`;
+Mask.parameters = {
+  docs: {
+    description: {
+      story:
+        'O atributo `mask` formata o valor enquanto o usuário digita. Use `9` para um dígito e `*` para letra ou dígito.',
+    },
+  },
+};
+
+export const MaskExamples = () => {
+  const container = document.createElement('div');
+  container.style.cssText =
+    'display: flex; flex-direction: column; gap: 16px; width: 280px;';
+  container.innerHTML = `
+    <lui-input label="CEP" mask="99999-999" placeholder="00000-000" size="lg"></lui-input>
+    <lui-input label="CPF" mask="999.999.999-99" placeholder="000.000.000-00" size="lg"></lui-input>
+    <lui-input label="CNPJ" mask="**.***.***/****-99" placeholder="00.000.000/0001-00" size="lg"></lui-input>
+    <lui-input label="Data" mask="99/99/9999" placeholder="DD/MM/AAAA" size="lg"></lui-input>
+    <lui-input label="Número do cartão" mask="9999 9999 9999 9999" placeholder="0000 0000 0000 0000" size="lg"></lui-input>
+    <lui-input label="Validade do cartão" mask="99/99" placeholder="MM/AA" size="lg"></lui-input>
+  `;
+  return container;
+};
+MaskExamples.storyName = 'Mask — exemplos prontos';
+MaskExamples.parameters = {
+  docs: {
+    description: {
+      story:
+        'Os seis padrões cobertos hoje: CEP, CPF, CNPJ (modelo alfanumérico, com letras automaticamente convertidas para maiúsculas), Data, Número do cartão e Validade do cartão.',
+    },
+  },
+};
 
 export const Required = () => `
   <div style="width: 244px;">

--- a/packages/lets-ui-components/src/components/input/input.ts
+++ b/packages/lets-ui-components/src/components/input/input.ts
@@ -62,6 +62,7 @@ export class LuiInput extends LitElement {
   @property() maxlength = '';
   @property() prefix = '';
   @property() suffix = '';
+  @property() mask = '';
   @property({ attribute: 'force-state' }) forceState = '';
   @property() min = '';
   @property() max = '';
@@ -74,6 +75,7 @@ export class LuiInput extends LitElement {
   @query('.input-field__input') private _inputEl!: HTMLInputElement;
 
   private _baseId: string;
+  private _previousMasked = '';
 
   constructor() {
     super();
@@ -144,6 +146,86 @@ export class LuiInput extends LitElement {
     return next;
   }
 
+  private _applyMask(raw: string): string {
+    const mask = this.mask;
+    if (!mask) return raw;
+    let result = '';
+    let valueIndex = 0;
+    for (let i = 0; i < mask.length; i++) {
+      const maskChar = mask[i];
+      if (maskChar === '9' || maskChar === '*') {
+        let found = false;
+        while (valueIndex < raw.length) {
+          const ch = raw[valueIndex];
+          valueIndex++;
+          if (maskChar === '9' && /[0-9]/.test(ch)) {
+            result += ch;
+            found = true;
+            break;
+          }
+          if (maskChar === '*' && /[0-9a-zA-Z]/.test(ch)) {
+            result += ch.toUpperCase();
+            found = true;
+            break;
+          }
+        }
+        if (!found) break;
+      } else {
+        result += maskChar;
+        if (raw[valueIndex] === maskChar) valueIndex++;
+      }
+    }
+    return result;
+  }
+
+  // Backspacing a mask literal (e.g. the "-" in a CEP) removes no real character on its
+  // own, so this also peels the preceding digit/letter — otherwise backspace would no-op.
+  private _applyMaskToInput() {
+    const native = this._inputEl;
+    const caret = native.selectionStart ?? native.value.length;
+    const browserValue = native.value;
+
+    let contentBeforeCaret = browserValue
+      .slice(0, caret)
+      .replace(/[^0-9a-zA-Z]/g, '').length;
+    let raw = browserValue;
+
+    const isSingleCharRemoval =
+      browserValue.length === this._previousMasked.length - 1 &&
+      browserValue ===
+        this._previousMasked.slice(0, caret) +
+          this._previousMasked.slice(caret + 1);
+
+    if (isSingleCharRemoval) {
+      const deletedChar = this._previousMasked[caret];
+      if (
+        deletedChar &&
+        !/[0-9a-zA-Z]/.test(deletedChar) &&
+        contentBeforeCaret > 0
+      ) {
+        const contentChars = browserValue
+          .split('')
+          .filter((c) => /[0-9a-zA-Z]/.test(c));
+        contentChars.splice(contentBeforeCaret - 1, 1);
+        raw = contentChars.join('');
+        contentBeforeCaret -= 1;
+      }
+    }
+
+    const masked = this._applyMask(raw);
+    native.value = masked;
+    this._previousMasked = masked;
+
+    let pos = 0;
+    let count = 0;
+    while (pos < masked.length && count < contentBeforeCaret) {
+      if (/[0-9a-zA-Z]/.test(masked[pos])) count++;
+      pos++;
+    }
+    while (pos < masked.length && !/[0-9a-zA-Z]/.test(masked[pos])) pos++;
+    native.setSelectionRange(pos, pos);
+  }
+
   formDisabledCallback(disabled: boolean) {
     this.disabled = disabled;
   }
@@ -151,6 +233,7 @@ export class LuiInput extends LitElement {
   formResetCallback() {
     this.value = '';
     this._charCount = 0;
+    this._previousMasked = '';
     this.error = false;
     if (this._inputEl) this._inputEl.value = '';
     this._syncFormValue();
@@ -173,6 +256,8 @@ export class LuiInput extends LitElement {
   private _handleInput() {
     if (this._inputType === 'number') {
       this._inputEl.value = String(this._clampNumber(this._inputEl.value));
+    } else if (this.mask) {
+      this._applyMaskToInput();
     }
     this._charCount = this._inputEl.value.length;
     this.error = false;


### PR DESCRIPTION
## Summary

- Adds an opt-in `mask` attribute to `lui-input`, implemented as a lightweight pattern engine (`9` = digit, `*` = letter or digit) with no external dependency.
- Covers the six formats scoped in #66: CEP, CPF, CNPJ (new alphanumeric model — first 12 characters letter or digit, last 2 check digits numeric-only, letters auto-uppercased), Date, Credit card number, and Card expiry.
- Typing auto-inserts mask literals and silently rejects keystrokes that don't match the expected placeholder type. Backspacing over a literal (e.g. the `-` in a CEP) also removes the adjacent digit/letter so backspace never feels stuck on punctuation.
- When `mask` is unset, behavior is unchanged — existing consumers and any external/custom masking via the bubbling `input`/`change` events keep working.
- The form value / `input`/`change` payload carries the masked (formatted) string, same as native `<input>.value` semantics; documented in the MDX how to strip punctuation if only raw characters are needed.
- Adds Storybook stories (`Mask`, `Mask — exemplos prontos`) and an MDX section documenting the placeholder syntax, the six bundled presets, and the emitted-value semantics.

Closes #66

## Test plan

- [x] Verified the mask engine against all 6 patterns (CEP, CPF, CNPJ, Date, Credit card, Card expiry) with a standalone script exercising the exact algorithm character-by-character, including invalid-character rejection and backspace-over-literal collapsing (16/16 checks passing)
- [x] `pnpm build` (lets-ui-components) succeeds
- [x] `pnpm build-storybook` succeeds, no MDX/story compile errors
- [x] `pnpm lint:css` passes (no SCSS touched)
- [x] Manually exercised all 6 masks in a local playground page (not included in this PR) via `pnpm --prefix playground dev`
- [x] Manual review of `Input.docs.mdx` rendering in `pnpm storybook`