### PR TITLE
feat(input): add pattern and inputmode support

### DIFF
--- a/.changeset/warm-lagoon-glow.md
+++ b/.changeset/warm-lagoon-glow.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+Add `pattern` and `inputmode` attribute support to the Input component, enabling regex-based validation via the Constraint Validation API and optimized virtual keyboards on touch devices.

--- a/packages/lets-ui-components/src/components/input/Input.docs.mdx
+++ b/packages/lets-ui-components/src/components/input/Input.docs.mdx
@@ -43,13 +43,41 @@ consistente com elementos nativos. A mensagem reportada é controlada pelo atrib
 
 <Canvas of={InputStories.FormIntegration} />
 
+### Pattern
+
+O atributo `pattern` aceita uma expressão regular para validar o valor final do campo,
+via Constraint Validation API. Quando o valor não casa com o padrão, o campo reporta
+`patternMismatch` através de `ElementInternals.setValidity()`, exibindo a mensagem de
+`error-text`. Útil para indicar formato esperado de forma declarativa, como CEP ou
+CPF/CNPJ sem máscara.
+
+<Canvas of={InputStories.Pattern} />
+
+### Input Mode
+
+O atributo `inputmode` é refletido no `<input>` nativo e otimiza o teclado virtual
+exibido em dispositivos touch para o tipo de dado esperado, sem alterar o tipo nativo
+do campo (`type`). Aceita os valores padrão: `text`, `numeric`, `decimal`, `tel`,
+`email`, `url`, `search` e `none`.
+
+<Canvas of={InputStories.InputMode} />
+
+### Pattern + Input Mode
+
+`pattern` e `inputmode` podem ser combinados — o teclado é otimizado para entrada de
+dados enquanto a regex valida o valor final, útil para campos como CPF/CNPJ sem máscara.
+
+<Canvas of={InputStories.PatternAndInputMode} />
+
 ## Atributos de formulário
 
-| Atributo   | Tipo      | Padrão | Descrição                                                                    |
-| ---------- | --------- | ------ | ---------------------------------------------------------------------------- |
-| `name`     | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`   |
-| `form`     | `string`  | `''`   | ID do `<form>` associado; permite usar o input fora do elemento form         |
-| `required` | `boolean` | `false`| Bloqueia a submissão quando o campo está vazio; valida via `ElementInternals`|
+| Atributo    | Tipo      | Padrão | Descrição                                                                                  |
+| ----------- | --------- | ------ | ------------------------------------------------------------------------------------------- |
+| `name`      | `string`  | `''`   | Nome do campo nos dados submetidos; necessário para aparecer no `FormData`                 |
+| `form`      | `string`  | `''`   | ID do `<form>` associado; permite usar o input fora do elemento form                       |
+| `required`  | `boolean` | `false`| Bloqueia a submissão quando o campo está vazio; valida via `ElementInternals`              |
+| `pattern`   | `string`  | `''`   | Regex para validar o valor final; reporta `patternMismatch` via `ElementInternals`          |
+| `inputmode` | `string`  | `''`   | Dica de teclado virtual em dispositivos touch (`text`, `numeric`, `decimal`, `tel`, `email`, `url`, `search`, `none`) |
 
 ## Classe CSS (sem Web Component)
 

--- a/packages/lets-ui-components/src/components/input/Input.stories.js
+++ b/packages/lets-ui-components/src/components/input/Input.stories.js
@@ -73,6 +73,23 @@ export default {
     step: {
       control: 'number',
     },
+    pattern: {
+      control: 'text',
+    },
+    inputmode: {
+      control: { type: 'select' },
+      options: [
+        '',
+        'text',
+        'numeric',
+        'decimal',
+        'tel',
+        'email',
+        'url',
+        'search',
+        'none',
+      ],
+    },
   },
 };
 
@@ -97,6 +114,8 @@ const Template = ({
   min,
   max,
   step,
+  pattern,
+  inputmode,
 }) => {
   const attrs = [
     `type="${type ?? 'text'}"`,
@@ -121,6 +140,8 @@ const Template = ({
     Number.isFinite(Number(min)) ? `min="${Number(min)}"` : '',
     Number.isFinite(Number(max)) ? `max="${Number(max)}"` : '',
     Number.isFinite(Number(step)) ? `step="${Number(step)}"` : '',
+    pattern ? `pattern="${pattern}"` : '',
+    inputmode ? `inputmode="${inputmode}"` : '',
   ]
     .filter(Boolean)
     .join('\n  ');
@@ -150,6 +171,8 @@ Input.args = {
   min: undefined,
   max: undefined,
   step: undefined,
+  pattern: '',
+  inputmode: '',
 };
 
 export const Error = () => `
@@ -220,6 +243,80 @@ Required.parameters = {
     description: {
       story:
         'Com `required`, o campo bloqueia a submissão do form quando vazio e reporta o erro via `ElementInternals.setValidity()`. A mensagem de erro exibida é controlada pelo atributo `error-text`.',
+    },
+  },
+};
+
+export const Pattern = () => `
+  <div style="width: 244px;">
+    <lui-input
+      name="cep"
+      label="CEP"
+      placeholder="00000-000"
+      pattern="[0-9]{5}-?[0-9]{3}"
+      size="lg"
+      hint="Formato: 00000-000"
+      error-text="CEP inválido. Use o formato 00000-000."
+    ></lui-input>
+  </div>
+`;
+Pattern.parameters = {
+  docs: {
+    description: {
+      story:
+        'Com `pattern`, o campo é validado por regex (via Constraint Validation API). Quando o valor não casa com o padrão, o campo reporta `patternMismatch` através de `ElementInternals.setValidity()`, exibindo a mensagem de `error-text`.',
+    },
+  },
+};
+
+export const InputMode = () => `
+  <div style="width: 244px; display: flex; flex-direction: column; gap: 16px;">
+    <lui-input
+      name="phone"
+      label="Telefone"
+      placeholder="(00) 00000-0000"
+      inputmode="tel"
+      size="lg"
+    ></lui-input>
+    <lui-input
+      name="email"
+      label="E-mail"
+      placeholder="seu@email.com"
+      inputmode="email"
+      size="lg"
+    ></lui-input>
+  </div>
+`;
+InputMode.storyName = 'Input Mode';
+InputMode.parameters = {
+  docs: {
+    description: {
+      story:
+        'Com `inputmode`, o teclado virtual exibido em dispositivos touch é otimizado para o tipo de dado esperado (ex.: `tel`, `email`, `numeric`), sem alterar o tipo nativo do campo.',
+    },
+  },
+};
+
+export const PatternAndInputMode = () => `
+  <div style="width: 244px;">
+    <lui-input
+      name="cpf"
+      label="CPF"
+      placeholder="000.000.000-00"
+      pattern="[0-9]{3}\\.?[0-9]{3}\\.?[0-9]{3}-?[0-9]{2}"
+      inputmode="numeric"
+      size="lg"
+      hint="Formato: 000.000.000-00"
+      error-text="CPF inválido."
+    ></lui-input>
+  </div>
+`;
+PatternAndInputMode.storyName = 'Pattern + Input Mode';
+PatternAndInputMode.parameters = {
+  docs: {
+    description: {
+      story:
+        'Combinando `pattern` e `inputmode`: o teclado numérico é exibido em dispositivos touch e o valor final é validado pela regex, útil para campos como CPF/CNPJ sem máscara.',
     },
   },
 };

--- a/packages/lets-ui-components/src/components/input/input.ts
+++ b/packages/lets-ui-components/src/components/input/input.ts
@@ -66,6 +66,8 @@ export class LuiInput extends LitElement {
   @property() min = '';
   @property() max = '';
   @property() step = '';
+  @property() pattern = '';
+  @property() inputmode = '';
   @property({ attribute: 'aria-label' }) ariaLabel = '';
 
   @state() private _passwordVisible = false;
@@ -165,6 +167,12 @@ export class LuiInput extends LitElement {
         this.errorText,
         this._inputEl
       );
+    } else if (this.pattern && this._inputEl?.validity.patternMismatch) {
+      this._internals.setValidity(
+        { patternMismatch: true },
+        this.errorText,
+        this._inputEl
+      );
     } else {
       this._internals.setValidity({});
     }
@@ -225,6 +233,8 @@ export class LuiInput extends LitElement {
           placeholder="${this.placeholder}"
           .value="${this.value}"
           maxlength="${maxLen !== null ? maxLen : ''}"
+          pattern="${ifDefined(this.pattern || undefined)}"
+          inputmode="${ifDefined(this.inputmode || undefined)}"
           ?disabled="${this.disabled}"
           ?required="${this.required}"
           ?aria-disabled="${this.disabled}"
@@ -282,6 +292,7 @@ export class LuiInput extends LitElement {
           step="${this._stepValue}"
           min="${minVal !== null ? minVal : ''}"
           max="${maxVal !== null ? maxVal : ''}"
+          inputmode="${ifDefined(this.inputmode || undefined)}"
           ?disabled="${this.disabled}"
           ?required="${this.required}"
           ?aria-disabled="${this.disabled}"


### PR DESCRIPTION
## Summary
- Adds `pattern` and `inputmode` properties to `lui-input`, reflected on the underlying native `<input>` element.
- Integrates `pattern` with `ElementInternals.setValidity()` (`patternMismatch`) in `_syncFormValue()`, following the same approach already used for `required`.
- Adds Storybook stories demonstrating `pattern` and `inputmode` isolated and combined.
- Documents the new attributes in the MDX docs and the form attributes table.

Closes #69

## Test plan
- [x] `pnpm lint:css` passes
- [x] `pnpm --filter @lets-ui/components build` passes
- [x] Verified in Storybook (headless browser) that `pattern`/`inputmode` propagate correctly to the shadow-DOM native `<input>` across the `Pattern`, `Input Mode`, and `Pattern + Input Mode` stories, with no console errors
- [x] Regression-checked the default `Input` story still renders cleanly with the new Controls (`pattern`, `inputmode`) wired in