### PR TITLE
feat(close-button): add lui-close-button component

### DIFF
--- a/.changeset/kind-river-soar.md
+++ b/.changeset/kind-river-soar.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+Add new `lui-close-button` component (`sm`/`md`/`lg` sizes, `disabled`, and `label` props) and integrate it into `lui-modal` and `lui-drawer`. Also adds `pattern` and `inputmode` props to `lui-input`, and fixes missing ARIA attributes across form controls and interactive components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.6.0
+
+### Added
+
+- New `lui-close-button` Web Component — dedicated close/dismiss button with `size` (`sm` | `md` | `lg`), `disabled`, and `label` props; also registered in `letsui.min.css` as a CSS-only component.
+- New `dismissible` boolean prop on `lui-alert` — renders a `lui-close-button` inside the alert and emits a `lui-dismiss` custom event when clicked; `close-label` prop overrides the accessible button label.
+- New `pattern` and `inputmode` props on `lui-input` for native HTML input validation and virtual keyboard hints.
+
+### Changed
+
+- `lui-drawer` and `lui-modal` now use `lui-close-button` internally, replacing the previous inline close button markup.
+
+### Fixed
+
+- Add `aria-invalid` and `aria-required` attributes to form controls (`lui-input`, `lui-select`, `lui-textarea`, `lui-checkbox`, `lui-switch`) for better screen reader compatibility.
+- Fix missing ARIA attributes across interactive components (`lui-modal`, `lui-drawer`, `lui-tabs`, `lui-dropdown-menu`, `lui-tooltip`).
+
+[Compare: v1.5.1...v1.6.0](https://github.com/mateusvillain/lets-ui/compare/v1.5.1...v1.6.0)
+
 ## v1.5.1
 
 ### Fixed

--- a/packages/lets-ui-components/package.json
+++ b/packages/lets-ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-ui/components",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Let's UI Web Components package",
   "license": "MIT",
   "type": "module",

--- a/packages/lets-ui-components/src/components/alert/alert.ts
+++ b/packages/lets-ui-components/src/components/alert/alert.ts
@@ -71,6 +71,8 @@ export class LuiAlert extends LitElement {
   @property() variant = 'success';
   @property() title = '';
   @property() content = '';
+  @property({ type: Boolean }) dismissible = false;
+  @property({ attribute: 'close-label' }) closeLabel = 'Close';
 
   @state() private _actionsSlotted = false;
 
@@ -84,6 +86,12 @@ export class LuiAlert extends LitElement {
   private _handleActionsSlotChange(e: Event) {
     const slot = e.target as HTMLSlotElement;
     this._actionsSlotted = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
+  private _handleDismiss() {
+    this.dispatchEvent(
+      new CustomEvent('lui-dismiss', { bubbles: true, composed: true })
+    );
   }
 
   render() {
@@ -104,6 +112,13 @@ export class LuiAlert extends LitElement {
             <p id="${this._baseId}-title" class="body--lg">${this.title}</p>
             <p id="${this._baseId}-content" class="body--lg">${this.content}</p>
           </div>
+          ${this.dismissible
+            ? html`<lui-close-button
+                size="sm"
+                label="${this.closeLabel}"
+                @click="${this._handleDismiss}"
+              ></lui-close-button>`
+            : ''}
         </div>
         <div
           class="alert__actions"

--- a/packages/lets-ui-components/src/components/close-button/CloseButton.docs.mdx
+++ b/packages/lets-ui-components/src/components/close-button/CloseButton.docs.mdx
@@ -1,0 +1,82 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as CloseButtonStories from './CloseButton.stories';
+
+<Meta of={CloseButtonStories} />
+
+# Close Button
+
+Botão compacto e autossuficiente para dispensar ou fechar elementos de UI como modais, drawers, alerts e tags. Ao contrário do Icon Button, o Close Button já inclui o ícone X embutido e um `aria-label` padrão acessível, eliminando a necessidade de configuração repetitiva em cada uso.
+
+<Canvas of={CloseButtonStories.CloseButton} />
+<Controls of={CloseButtonStories.CloseButton} />
+
+## Tamanhos
+
+Três tamanhos disponíveis: `sm` (24px) para espaços compactos como tags e alerts, `md` (32px, padrão) para uso geral, e `lg` (40px) para cabeçalhos de modal e drawer.
+
+<Canvas of={CloseButtonStories.AllSizes} />
+
+## Disabled
+
+Use o estado desabilitado quando a ação de fechar não está disponível no contexto atual.
+
+<Canvas of={CloseButtonStories.Disabled} />
+
+## Dentro do Alert
+
+O atributo `dismissible` no `<lui-alert>` adiciona automaticamente um Close Button. Ao clicar, o componente emite o evento `lui-dismiss` — cabe ao consumidor remover ou ocultar o alert.
+
+<Canvas of={CloseButtonStories.InsideAlert} />
+
+## Dentro do Modal
+
+O cabeçalho do Modal usa o Close Button no tamanho `lg` para fechar o diálogo.
+
+<Canvas of={CloseButtonStories.InsideModal} />
+
+## Classe CSS (sem Web Component)
+
+<Canvas of={CloseButtonStories.CSSClass} />
+
+## Uso
+
+### Web Component
+
+```html
+<lui-close-button size="md" label="Close"></lui-close-button>
+```
+
+Personalizando o label:
+
+```html
+<lui-close-button size="lg" label="Fechar modal"></lui-close-button>
+```
+
+### Alert dismissível
+
+```html
+<lui-alert
+  variant="info"
+  title="Título"
+  content="Conteúdo"
+  dismissible
+></lui-alert>
+```
+
+Escutando o evento de dismiss:
+
+```js
+document.querySelector('lui-alert').addEventListener('lui-dismiss', () => {
+  // remover ou ocultar o alert
+});
+```
+
+### Classe CSS
+
+```html
+<button class="close-button close-button--lg" aria-label="Close">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M17.4697 5.46973..."/>
+  </svg>
+</button>
+```

--- a/packages/lets-ui-components/src/components/close-button/CloseButton.stories.js
+++ b/packages/lets-ui-components/src/components/close-button/CloseButton.stories.js
@@ -1,0 +1,85 @@
+import '../../../../../packages/lets-ui-tokens/dist/letsui.tokens.css';
+import '../../../../../packages/styles/dist/letsui.css';
+import '../../index.js';
+
+export default {
+  title: 'Actionable/Close Button',
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+    },
+    label: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+};
+
+const Template = ({ size, label, disabled }) =>
+  `<lui-close-button
+    size="${size}"
+    label="${label}"
+    ${disabled ? 'disabled' : ''}
+  ></lui-close-button>`;
+
+export const CloseButton = Template.bind({});
+CloseButton.args = {
+  size: 'md',
+  label: 'Close',
+  disabled: false,
+};
+
+export const SizeSm = Template.bind({});
+SizeSm.args = { size: 'sm', label: 'Close', disabled: false };
+SizeSm.storyName = 'Size: Small';
+
+export const SizeMd = Template.bind({});
+SizeMd.args = { size: 'md', label: 'Close', disabled: false };
+SizeMd.storyName = 'Size: Medium';
+
+export const SizeLg = Template.bind({});
+SizeLg.args = { size: 'lg', label: 'Close', disabled: false };
+SizeLg.storyName = 'Size: Large';
+
+export const Disabled = Template.bind({});
+Disabled.args = { size: 'md', label: 'Close', disabled: true };
+
+export const AllSizes = () => `
+  <div style="display: flex; gap: 16px; align-items: center;">
+    <lui-close-button size="sm" label="Close small"></lui-close-button>
+    <lui-close-button size="md" label="Close medium"></lui-close-button>
+    <lui-close-button size="lg" label="Close large"></lui-close-button>
+  </div>
+`;
+AllSizes.storyName = 'Todos os tamanhos';
+AllSizes.parameters = { controls: { disable: true } };
+
+export const InsideAlert = () => `
+  <lui-alert
+    variant="info"
+    title="Informação importante"
+    content="Este alert pode ser descartado clicando no botão fechar."
+    dismissible
+  ></lui-alert>
+`;
+InsideAlert.storyName = 'Dentro do Alert (dismissible)';
+InsideAlert.parameters = { controls: { disable: true } };
+
+export const InsideModal = () => `
+  <lui-modal title="Modal title" trigger-label="Abrir modal">
+    <p>O botão X no cabeçalho é um componente close-button.</p>
+  </lui-modal>
+`;
+InsideModal.storyName = 'Dentro do Modal';
+InsideModal.parameters = {
+  controls: { disable: true },
+  docs: { story: { height: '400px' } },
+};
+
+export const CSSClass = () => `
+  <button class="close-button close-button--lg" aria-label="Close">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M17.4697 5.46973C17.7626 5.17683 18.2373 5.17683 18.5302 5.46973C18.8231 5.76262 18.8231 6.23738 18.5302 6.53027L13.0605 12L18.5302 17.4697C18.8231 17.7626 18.8231 18.2374 18.5302 18.5303C18.2373 18.8232 17.7626 18.8232 17.4697 18.5303L11.9999 13.0605L6.53022 18.5303C6.23732 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9394 12L5.46967 6.53027C5.17678 6.23738 5.17678 5.76262 5.46967 5.46973C5.76256 5.17683 6.23732 5.17683 6.53022 5.46973L11.9999 10.9395L17.4697 5.46973Z"/>
+    </svg>
+  </button>
+`;
+CSSClass.storyName = 'Classe CSS (sem Web Component)';

--- a/packages/lets-ui-components/src/components/close-button/close-button.scss
+++ b/packages/lets-ui-components/src/components/close-button/close-button.scss
@@ -1,0 +1,5 @@
+@use 'packages/styles/src/components/close-button' as *;
+
+:host {
+  display: inline-flex;
+}

--- a/packages/lets-ui-components/src/components/close-button/close-button.ts
+++ b/packages/lets-ui-components/src/components/close-button/close-button.ts
@@ -1,0 +1,41 @@
+import { LitElement, html, unsafeCSS } from 'lit';
+import { property } from 'lit/decorators.js';
+import styles from './close-button.scss?inline';
+
+export class LuiCloseButton extends LitElement {
+  static styles = unsafeCSS(styles);
+
+  @property() size = 'md';
+  @property({ type: Boolean }) disabled = false;
+  @property() label = 'Close';
+
+  get _size(): 'sm' | 'md' | 'lg' {
+    const s = this.size;
+    return (['sm', 'md', 'lg'] as const).includes(s as 'sm' | 'md' | 'lg')
+      ? (s as 'sm' | 'md' | 'lg')
+      : 'md';
+  }
+
+  render() {
+    return html`
+      <button
+        type="button"
+        class="close-button close-button--${this._size}"
+        aria-label="${this.label}"
+        ?disabled="${this.disabled}"
+        ?aria-disabled="${this.disabled}"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M17.4697 5.46973C17.7626 5.17683 18.2373 5.17683 18.5302 5.46973C18.8231 5.76262 18.8231 6.23738 18.5302 6.53027L13.0605 12L18.5302 17.4697C18.8231 17.7626 18.8231 18.2374 18.5302 18.5303C18.2373 18.8232 17.7626 18.8232 17.4697 18.5303L11.9999 13.0605L6.53022 18.5303C6.23732 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9394 12L5.46967 6.53027C5.17678 6.23738 5.17678 5.76262 5.46967 5.46973C5.76256 5.17683 6.23732 5.17683 6.53022 5.46973L11.9999 10.9395L17.4697 5.46973Z"
+          />
+        </svg>
+      </button>
+    `;
+  }
+}

--- a/packages/lets-ui-components/src/components/drawer/drawer.ts
+++ b/packages/lets-ui-components/src/components/drawer/drawer.ts
@@ -230,23 +230,11 @@ export class LuiDrawer extends LitElement {
           <span id="${this._baseId}-title" class="drawer__title"
             >${this.title}</span
           >
-          <button
-            type="button"
-            class="drawer__close"
-            aria-label="Fechar drawer"
+          <lui-close-button
+            size="lg"
+            label="Fechar drawer"
             @click="${this.closeDrawer}"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                d="M17.4697 5.46973C17.7626 5.17683 18.2373 5.17683 18.5302 5.46973C18.8231 5.76262 18.8231 6.23738 18.5302 6.53027L13.0605 12L18.5302 17.4697C18.8231 17.7626 18.8231 18.2374 18.5302 18.5303C18.2373 18.8232 17.7626 18.8232 17.4697 18.5303L11.9999 13.0605L6.53022 18.5303C6.23732 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9394 12L5.46967 6.53027C5.17678 6.23738 5.17678 5.76262 5.46967 5.46973C5.76256 5.17683 6.23732 5.17683 6.53022 5.46973L11.9999 10.9395L17.4697 5.46973Z"
-              />
-            </svg>
-          </button>
+          ></lui-close-button>
         </div>
 
         <div id="${this._baseId}-body" class="drawer__body">

--- a/packages/lets-ui-components/src/components/modal/modal.ts
+++ b/packages/lets-ui-components/src/components/modal/modal.ts
@@ -205,23 +205,11 @@ export class LuiModal extends LitElement {
             <span id="${this._baseId}-title" class="modal__title"
               >${this.title}</span
             >
-            <button
-              type="button"
-              class="modal__close"
-              aria-label="Fechar modal"
+            <lui-close-button
+              size="lg"
+              label="Fechar modal"
               @click="${this.closeModal}"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  d="M17.4697 5.46973C17.7626 5.17683 18.2373 5.17683 18.5302 5.46973C18.8231 5.76262 18.8231 6.23738 18.5302 6.53027L13.0605 12L18.5302 17.4697C18.8231 17.7626 18.8231 18.2374 18.5302 18.5303C18.2373 18.8232 17.7626 18.8232 17.4697 18.5303L11.9999 13.0605L6.53022 18.5303C6.23732 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9394 12L5.46967 6.53027C5.17678 6.23738 5.17678 5.76262 5.46967 5.46973C5.76256 5.17683 6.23732 5.17683 6.53022 5.46973L11.9999 10.9395L17.4697 5.46973Z"
-                />
-              </svg>
-            </button>
+            ></lui-close-button>
           </div>
           <div id="${this._baseId}-body" class="modal__body">
             <slot></slot>

--- a/packages/lets-ui-components/src/index.ts
+++ b/packages/lets-ui-components/src/index.ts
@@ -29,6 +29,7 @@ import { LuiCheckbox } from './components/checkbox/checkbox.js';
 import { LuiRadio } from './components/radio/radio.js';
 import { LuiRadioGroup } from './components/radio-group/radio-group.js';
 import { LuiSwitch } from './components/switch/switch.js';
+import { LuiCloseButton } from './components/close-button/close-button.js';
 import { LuiIconButton } from './components/icon-button/icon-button.js';
 import { LuiInput } from './components/input/input.js';
 import { LuiLink } from './components/link/link.js';
@@ -79,6 +80,7 @@ define('lui-checkbox', LuiCheckbox);
 define('lui-radio', LuiRadio);
 define('lui-radio-group', LuiRadioGroup);
 define('lui-switch', LuiSwitch);
+define('lui-close-button', LuiCloseButton);
 define('lui-icon-button', LuiIconButton);
 define('lui-input', LuiInput);
 define('lui-link', LuiLink);
@@ -125,6 +127,7 @@ export {
   LuiRadio,
   LuiRadioGroup,
   LuiSwitch,
+  LuiCloseButton,
   LuiIconButton,
   LuiInput,
   LuiLink,

--- a/packages/lets-ui-tokens/package.json
+++ b/packages/lets-ui-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-ui/tokens",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Let's UI design tokens package",
   "license": "MIT",
   "type": "module",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-ui/styles",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Let's UI styles and components package",
   "license": "MIT",
   "type": "module",

--- a/packages/styles/src/components/_close-button.scss
+++ b/packages/styles/src/components/_close-button.scss
@@ -1,0 +1,55 @@
+@use '../utilities/functions' as *;
+@use '../utilities/mixins' as *;
+
+.close-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: radius(md);
+  cursor: pointer;
+  color: icon(neutral);
+  transition: background-color 0.2s ease-in-out;
+
+  svg {
+    display: block;
+    pointer-events: none;
+  }
+
+  &--sm {
+    width: fixed(24);
+    height: fixed(24);
+    padding: fluid(4);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+
+  &--md {
+    width: fixed(32);
+    height: fixed(32);
+    padding: fixed(8);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+
+  &--lg {
+    width: fixed(40);
+    height: fixed(40);
+    padding: fixed(8);
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+  }
+
+  @include states(neutral, primary, primary);
+}

--- a/packages/styles/src/components/_components.scss
+++ b/packages/styles/src/components/_components.scss
@@ -18,6 +18,7 @@
 @use 'card';
 @use 'checkbox';
 @use 'heading';
+@use 'close-button';
 @use 'icon-button';
 @use 'radio';
 @use 'switch';


### PR DESCRIPTION
## Summary

- New `lui-close-button` Web Component with `size` (`sm` | `md` | `lg`), `disabled`, and `label` props; registered as custom element and added to `letsui.min.css`
- `lui-modal` and `lui-drawer` replace their inline close `<button>` markup with `lui-close-button`
- Bumps all packages to `v1.6.0` and adds changelog entry

## Test plan

- [x] `lui-close-button` renders correctly in `sm`, `md`, and `lg` sizes
- [x] `lui-close-button` with `disabled` blocks interaction and sets `aria-disabled`
- [x] `lui-modal` and `lui-drawer` close buttons still work as expected
- [x] Storybook stories for `lui-close-button` render without errors
- [x] `letsui.min.css` includes close-button styles after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)