### PR TITLE
feat(alert): add dismissible prop with close button

### DIFF
--- a/.changeset/calm-heron-shine.md
+++ b/.changeset/calm-heron-shine.md
@@ -1,0 +1,7 @@
+---
+'@lets-ui/components': minor
+'@lets-ui/styles': minor
+'@lets-ui/tokens': minor
+---
+
+Add `dismissible` prop to `lui-alert` — renders a close button and emits a `lui-dismiss` event when clicked; `close-label` prop customizes the accessible button label.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 
 - New `lui-close-button` Web Component — dedicated close/dismiss button with `size` (`sm` | `md` | `lg`), `disabled`, and `label` props; also registered in `letsui.min.css` as a CSS-only component.
-- New `dismissible` boolean prop on `lui-alert` — renders a `lui-close-button` inside the alert and emits a `lui-dismiss` custom event when clicked; `close-label` prop overrides the accessible button label.
 - New `pattern` and `inputmode` props on `lui-input` for native HTML input validation and virtual keyboard hints.
+- New `dismissible` boolean prop on `lui-alert` — renders a `lui-close-button` and emits a `lui-dismiss` custom event when clicked; `close-label` prop customizes the accessible button label.
 
 ### Changed
 

--- a/packages/lets-ui-components/src/components/alert/Alert.docs.mdx
+++ b/packages/lets-ui-components/src/components/alert/Alert.docs.mdx
@@ -27,7 +27,6 @@ Adicione o atributo `dismissible` para exibir um botão de fechar no canto do al
 O label acessível do botão pode ser customizado com o atributo `close-label` (padrão: `"Close"`).
 
 <Canvas of={AlertStories.Dismissible} />
-<Controls of={AlertStories.Dismissible} />
 
 ### Dismissible com ações
 

--- a/packages/lets-ui-components/src/components/alert/Alert.docs.mdx
+++ b/packages/lets-ui-components/src/components/alert/Alert.docs.mdx
@@ -20,6 +20,23 @@ import * as AlertStories from './Alert.stories';
 ## Success
 <Canvas of={AlertStories.Success} />
 
+## Dismissible
+
+Adicione o atributo `dismissible` para exibir um botão de fechar no canto do alert. Ao ser clicado, o componente emite o evento `lui-dismiss` — use-o para remover o alert do DOM ou atualizar o estado da aplicação.
+
+O label acessível do botão pode ser customizado com o atributo `close-label` (padrão: `"Close"`).
+
+<Canvas of={AlertStories.Dismissible} />
+<Controls of={AlertStories.Dismissible} />
+
+### Dismissible com ações
+
+<Canvas of={AlertStories.DismissibleWithActions} />
+
+### Todos os variants
+
+<Canvas of={AlertStories.DismissibleAllVariants} />
+
 ## Classe CSS (sem Web Component)
 
 <Canvas of={AlertStories.CSSClass} />
@@ -30,6 +47,24 @@ import * as AlertStories from './Alert.stories';
 
 ```html
 <lui-alert variant="info" title="Título" content="Informação importante"></lui-alert>
+```
+
+### Dismissible
+
+```html
+<lui-alert
+  variant="caution"
+  title="Atenção"
+  content="Esta ação não pode ser desfeita."
+  dismissible
+  close-label="Fechar alerta"
+></lui-alert>
+
+<script>
+  document.querySelector('lui-alert').addEventListener('lui-dismiss', (e) => {
+    e.target.remove();
+  });
+</script>
 ```
 
 ### Classe CSS

--- a/packages/lets-ui-components/src/components/alert/Alert.stories.js
+++ b/packages/lets-ui-components/src/components/alert/Alert.stories.js
@@ -11,14 +11,24 @@ export default {
     },
     title: { control: 'text' },
     content: { control: 'text' },
+    dismissible: {
+      control: 'boolean',
+      table: { defaultValue: { summary: false } },
+    },
+    closeLabel: {
+      control: 'text',
+      name: 'close-label',
+    },
   },
 };
 
-const Template = ({ variant, title, content }) => `
+const Template = ({ variant, title, content, dismissible, closeLabel }) => `
   <lui-alert
     variant="${variant ?? 'success'}"
     title="${title ?? ''}"
     content="${content ?? ''}"
+    ${dismissible ? 'dismissible' : ''}
+    ${closeLabel ? `close-label="${closeLabel}"` : ''}
   >
     <button slot="actions" class="btn btn--secondary btn--lg">Dismiss</button>
     <button slot="actions" class="btn btn--primary btn--lg">Action</button>
@@ -29,6 +39,8 @@ const baseArgs = {
   variant: 'success',
   title: 'Alert title',
   content: 'Description',
+  dismissible: false,
+  closeLabel: 'Close',
 };
 
 export const Alert = Template.bind({});
@@ -45,6 +57,51 @@ Danger.args = { ...baseArgs, variant: 'danger' };
 
 export const Info = Template.bind({});
 Info.args = { ...baseArgs, variant: 'info' };
+
+export const Dismissible = ({ variant, title, content, closeLabel }) => `
+  <lui-alert
+    variant="${variant ?? 'info'}"
+    title="${title ?? 'Alert title'}"
+    content="${content ?? 'This alert can be dismissed by clicking the close button.'}"
+    dismissible
+    close-label="${closeLabel ?? 'Close'}"
+  ></lui-alert>
+`;
+Dismissible.args = {
+  variant: 'info',
+  title: 'Alert title',
+  content: 'This alert can be dismissed by clicking the close button.',
+  closeLabel: 'Close',
+};
+Dismissible.argTypes = {
+  dismissible: { table: { disable: true } },
+};
+
+export const DismissibleWithActions = () => `
+  <lui-alert
+    variant="caution"
+    title="Unsaved changes"
+    content="You have unsaved changes. Do you want to save before leaving?"
+    dismissible
+    close-label="Discard changes"
+  >
+    <button slot="actions" class="btn btn--secondary btn--lg">Cancel</button>
+    <button slot="actions" class="btn btn--primary btn--lg">Save</button>
+  </lui-alert>
+`;
+DismissibleWithActions.storyName = 'Dismissible with actions';
+DismissibleWithActions.parameters = { controls: { disable: true } };
+
+export const DismissibleAllVariants = () => `
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <lui-alert variant="success" title="Success" content="Your changes have been saved." dismissible></lui-alert>
+    <lui-alert variant="caution" title="Caution" content="Please review the information before proceeding." dismissible></lui-alert>
+    <lui-alert variant="danger" title="Danger" content="This action cannot be undone." dismissible></lui-alert>
+    <lui-alert variant="info" title="Info" content="A new version is available." dismissible></lui-alert>
+  </div>
+`;
+DismissibleAllVariants.storyName = 'Dismissible — all variants';
+DismissibleAllVariants.parameters = { controls: { disable: true } };
 
 export const WithoutActions = () => `
   <lui-alert

--- a/packages/lets-ui-components/src/components/alert/alert.ts
+++ b/packages/lets-ui-components/src/components/alert/alert.ts
@@ -114,7 +114,7 @@ export class LuiAlert extends LitElement {
           </div>
           ${this.dismissible
             ? html`<lui-close-button
-                size="sm"
+                size="lg"
                 label="${this.closeLabel}"
                 @click="${this._handleDismiss}"
               ></lui-close-button>`

--- a/playground/src/pages/index.astro
+++ b/playground/src/pages/index.astro
@@ -277,6 +277,10 @@ import 'lets-ui-icons/dist/lets-ui-icons.css';
 
     <script>
       import '@lets-ui/components';
+
+      document.addEventListener('lui-dismiss', (e) => {
+        (e.target as HTMLElement).remove();
+      });
     </script>
   </body>
 


### PR DESCRIPTION
## Summary

- New `dismissible` boolean prop on `lui-alert` — renders a `lui-close-button` (`lg`) and emits a `lui-dismiss` custom event when clicked
- New `close-label` prop to customize the accessible button label (default: `"Close"`)
- Storybook: `Dismissible`, `Dismissible with actions`, and `Dismissible — all variants` stories
- `Alert.docs.mdx` updated with a dedicated Dismissible section and `lui-dismiss` event usage example

> **Note:** This PR depends on #76 (`feat/close-button`) and targets that branch as base.

## Test plan

- [x] `dismissible` renders `lui-close-button` inside the alert
- [x] Clicking the close button emits `lui-dismiss` (`bubbles: true, composed: true`)
- [x] `close-label` customizes the button's `aria-label`
- [x] Without `dismissible`, no close button is rendered
- [x] Storybook stories render correctly for all variants
- [x] ArgTypes table shows `dismissible` default as `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)