### PR TITLE
docs(a11y): document close-label prop and lui-close-button contract

### DIFF
--- a/A11Y.md
+++ b/A11Y.md
@@ -361,9 +361,20 @@ Password toggle button requires `aria-label` describing current action (`"Mostra
 ### lui-modal / lui-drawer
 
 - `inert` attribute applied when closed; removed when open.
-- Close button aria-label must be descriptive: `"Fechar modal"` / `"Fechar drawer"`.
+- Close button `aria-label` is controlled by the `close-label` prop. Defaults: `"Fechar modal"` for `lui-modal`, `"Fechar drawer"` for `lui-drawer`. Consumers must override this value when rendering in a non-Portuguese context.
 - SVG inside close button: `aria-hidden="true"`.
 - `aria-hidden` on backdrop element (opposite value to `open`).
+
+### lui-close-button
+
+| Property          | Requirement                                                                     |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `aria-label`      | Required — set via the `label` prop (default: `"Close"`). Never leave it empty. |
+| `aria-disabled`   | Must be `"true"` when `disabled` is true                                        |
+| Native `<button>` | Always; `type="button"` to prevent accidental form submission                   |
+| SVG icon          | Decorative — must have `aria-hidden="true"`                                     |
+
+When used inside another component (e.g. `lui-alert`, `lui-modal`, `lui-drawer`), the parent is responsible for providing a contextually meaningful `label` prop (e.g. `"Fechar modal"`, `"Fechar alerta"`).
 
 ### lui-tabs
 


### PR DESCRIPTION
## Summary

- Updates `lui-modal / lui-drawer` section in `A11Y.md` to document `close-label` as a configurable prop, with the PT-BR defaults as fallback and a note for non-Portuguese consumers
- Adds a new `lui-close-button` component-specific contract table covering `aria-label`, `aria-disabled`, native `<button>` and SVG requirements

Closes #62

## Test plan

- [x] `A11Y.md` section `lui-modal / lui-drawer` mentions `close-label` with its defaults
- [x] `A11Y.md` includes a `lui-close-button` contract table under component-specific contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)